### PR TITLE
chore: add release-please ci

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -1,0 +1,23 @@
+policies:
+  - type: commit
+    spec:
+      header:
+        length: 89
+        imperative: true
+        case: lower
+        invalidLastCharacters: .
+        jira:
+          keys: []
+      body:
+        required: true
+      dco: false
+      gpg:
+        required: true
+        identity: {}
+      spellcheck:
+        locale: US
+      maximumOfOneCommit: false
+      conventional:
+        types: []
+        scopes: []
+        descriptionLength: 72

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,27 +1,26 @@
 name: CI
-
 on:
   push:
     branches: [master]
   pull_request:
     branches: [master]
-
 jobs:
+  conform:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Conform Action
+        uses: siderolabs/conform@v0.1.0-alpha.27
   lint-and-test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-
-    - name: Use Node.js
-      uses: actions/setup-node@v3
-      with:
+      - uses: actions/checkout@v3
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
           node-version: "18.x"
-
-    - name: Install modules
-      run: npm install
-
-    - name: Lint
-      run: npm run lint
-
-    - name: Build
-      run: npm run build
+      - name: Install modules
+        run: npm install
+      - name: Lint
+        run: npm run lint
+      - name: Build
+        run: npm run build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,16 @@
+on:
+    push:
+        branches:
+            - main
+permissions:
+    contents: write
+    pull-requests: write
+name: release-please
+jobs:
+    release-please:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: google-github-actions/release-please-action@v3
+              with:
+                  release-type: node
+                  package-name: obsidian-kobo-highlights-importer-plugin


### PR DESCRIPTION
Add conform and release-please CI jobs to manage releases for this package.

Conform will be used to ensure that conventional commits are enforced.