### PR TITLE
chore: fix release-please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,4 +1,6 @@
 {
+  "include-v-in-tag": false,
+  "include-component-in-tag": false,
   "packages": {
     ".": {
       "changelog-path": "CHANGELOG.md",


### PR DESCRIPTION
Inlcuding the v tag in release name and tag is not according to Obsidian plugin spec.

Relates-To: https://github.com/OGKevin/obsidian-kobo-highlights-import/issues/143
Release-As: 1.5.2