### PR TITLE
chore: run workflow on published releases

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,7 +3,7 @@ name: Build plugin
 on:
   release:
     types:
-      - "unpublished" 
+      - "published" 
 
 env:
   PLUGIN_NAME: kobo-highlights-import
@@ -58,7 +58,3 @@ jobs:
           asset_path: ./manifest.json
           asset_name: manifest.json
           asset_content_type: application/json
-      - uses: eregon/publish-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,7 @@
       "release-type": "node",
       "bump-minor-pre-major": false,
       "bump-patch-for-minor-pre-major": false,
-      "draft": true,
+      "draft": false,
       "prerelease": false,
       "extra-files": [
         {


### PR DESCRIPTION
Github will not sent events for draft releases.

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release

So this workflow won't work, we the release must be published for the workflow to kick in.