### PR TITLE
fix: add wildcard at the beginning of like query

### DIFF
--- a/src/database/repository.ts
+++ b/src/database/repository.ts
@@ -89,7 +89,7 @@ export class Repository {
             `select 
                 Title, ContentID, ChapterIDBookmarked, BookTitle from content
                 where ContentID like $id;`,
-            { $id: `${contentId}%` },
+            { $id: `%${contentId}%` },
         )
         const contents = this.parseContentStatement(statement)
         statement.free()


### PR DESCRIPTION
fix: add wildcard at the beginning of like query

By adding a wildcard at the beginning of the LIKE query that tries to search for content/books, we increase the chances of getting a hit.

The missing wild card makes the following scenario fail:
```
file:///mnt/onboard/Digital Editions/Problem Solved.epub#(40)ops/xhtml/appendixb.html
```

```sql
select Title, ContentID, ChapterIDBookmarked, BookTitle from content where ContentID like "ops/xhtml/appendixb.html%";
```

By adding  `%` at the beginning, it will find the content.

Fixes: https://github.com/OGKevin/obsidian-kobo-highlights-import/issues/152
Release-As: 1.5.3
