### PR TITLE
fix: don't crash when there are no highlights

### DIFF
--- a/src/database/repository.ts
+++ b/src/database/repository.ts
@@ -12,6 +12,12 @@ export class Repository {
         const res = this.db.exec(`select Text, ContentID, annotation, DateCreated from Bookmark where Text is not null;`)
         const bookmakrs: Bookmark[] = []
 
+        if (res[0].values == undefined) {
+            console.warn("Bookmarks table returend no results, do you have any annotations created?")
+
+            return bookmakrs
+        }
+
         res[0].values.forEach(row => {
             if (!(row[0] && row[1] && row[3])) {
                 console.warn(

--- a/src/modal/ExtractHighlightsModal.ts
+++ b/src/modal/ExtractHighlightsModal.ts
@@ -17,10 +17,13 @@ export class ExtractHighlightsModal extends Modal {
 
     sqlFilePath: string | undefined
 
+    nrOfBooksExtracted: number
+
     constructor(
         app: App, settings: KoboHighlightsImporterSettings) {
         super(app);
         this.settings = settings
+        this.nrOfBooksExtracted = 0
     }
 
     private async fetchHighlights() {
@@ -49,6 +52,7 @@ export class ExtractHighlightsModal extends Modal {
             this.settings.annotationCallout
         )
 
+        this.nrOfBooksExtracted = content.size
         const template = await getTemplateContents(this.app, this.settings.templatePath)
 
         for (const [bookTitle, chapters] of content) {
@@ -73,7 +77,7 @@ export class ExtractHighlightsModal extends Modal {
             new Notice('Extracting highlights...')
             this.fetchHighlights()
                 .then(() => {
-                    new Notice('Highlights extracted!')
+                    new Notice('Extracted highlights from ' + this.nrOfBooksExtracted + ' books!')
                     this.close()
                 }).catch(e => {
                     console.log(e)


### PR DESCRIPTION
There is a scenario where the bookmarks table will return no results. In this case, the code should return an empty list which shall result in the code continue its normal execution with a list with 0 elements.

Release-As: 1.5.4
Fixes: https://github.com/OGKevin/obsidian-kobo-highlights-import/issues/158