### PR TITLE
fix: make type marker a comment

### DIFF
--- a/src/database/Highlight.ts
+++ b/src/database/Highlight.ts
@@ -12,7 +12,7 @@ type bookmark = {
     highlightContent: string
 }
 
-export const typeWhateverYouWantPlaceholder = `--> Here you can type whatever you want, it will not be overwritten by the plugin. <--`
+export const typeWhateverYouWantPlaceholder = `%% Here you can type whatever you want, it will not be overwritten by the plugin. %%`
 
 export class HighlightService {
     repo: Repository


### PR DESCRIPTION
This ensures that when in non edit mode, the type marker is not visible.

https://github.com/OGKevin/obsidian-kobo-highlights-import/issues/91