### PR TITLE
chore: remove file caching from renovate

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - arc-runner

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -3,23 +3,6 @@ on:
   schedule:
     - cron: "0 0 */1 * *"
   workflow_dispatch:
-    inputs:
-      repoCache:
-        description: "Reset or disable the cache?"
-        type: choice
-        default: enabled
-        options:
-          - enabled
-          - disabled
-          - reset
-env:
-  cache_archive: renovate_cache.tar.gz
-  # This is the dir renovate provides -- if we set our own directory via cacheDir, we can run into permissions issues.
-  # It is also possible to cache a higher level of the directory, but it has minimal benefit. While renovate execution
-  # time gets faster, it also takes longer to upload the cache as it grows bigger.
-  cache_dir: /tmp/renovate/cache/renovate/repository
-  # This can be manually changed to bust the cache if neccessary.
-  cache_key: renovate-cache
 jobs:
   renovate:
     runs-on: arc-runner
@@ -34,9 +17,9 @@ jobs:
           while read -r line;
           do
             echo "::add-mask::${line}";
-          done <<< $private_key
+          done <<< "$private_key"
           {
-            echo 'GITHUB_PRIVATE_KEY<<EOF'
+            echo "GITHUB_PRIVATE_KEY<<EOF"
             echo "$private_key"
             echo EOF
           } >> "$GITHUB_ENV"
@@ -57,60 +40,7 @@ jobs:
           app-id: ${{ env.GITHUB_APP_ID }}
       - name: Checkout
         uses: actions/checkout@v4.1.1
-      # This third party action allows you to download the cache artifact from different workflow runs
-      # Note that actions/cache doesn't work well because the cache key would need to be computed from
-      # a file within the cache, meaning there would never be any data to restore. With other keys, the
-      # cache wouldn't necessarily upload when it changes. actions/download-artifact also doesn't work
-      # because it only handles artifacts uploaded in the same run, and we want to restore from the
-      # previous successful run.
-      - uses: dawidd6/action-download-artifact@v2
-        if: github.event.inputs.repoCache != 'disabled'
-        continue-on-error: true
-        with:
-          name: ${{ env.cache_key }}
-          path: cache-download
-      # Using tar to compress and extract the archive isn't strictly necessary, but it can improve
-      # performance significantly when uploading artifacts with lots of files.
-      - name: Extract renovate cache
-        run: |
-          set -x
-          # Skip if no cache is set, such as the first time it runs.
-          if [ ! -d cache-download ] ; then
-            echo "No cache found."
-            exit 0
-          fi
-
-          # Make sure the directory exists, and extract it there. Note that it's nested in the download directory.
-          mkdir -p $cache_dir
-          tar -xzf cache-download/$cache_archive -C $cache_dir
-
-          # Unfortunately, the permissions expected within renovate's docker container
-          # are different than the ones given after the cache is restored. We have to
-          # change ownership to solve this. We also need to have correct permissions in
-          # the entire /tmp/renovate tree, not just the section with the repo cache.
-          sudo chown -R runneradmin:root /tmp/renovate/
-          ls -R $cache_dir
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@v40.1.3
         with:
           token: "${{ steps.get_token.outputs.token }}"
-        env:
-          # This enables the cache -- if this is set, it's not necessary to add it to renovate.jjson.
-          RENOVATE_REPOSITORY_CACHE: ${{ github.event.inputs.repoCache || 'enabled' }}
-      # Compression helps performance in the upload step!
-      - name: Compress renovate cache
-        run: |
-          ls $cache_dir
-          # The -C is important -- otherwise we end up extracting the files with
-          # their full path, ultimately leading to a nested directory situation.
-          # To solve *that*, we'd have to extract to root (/), which isn't safe.
-          tar -czvf $cache_archive -C $cache_dir .
-      - uses: actions/upload-artifact@v4
-        if: github.event.inputs.repoCache != 'disabled'
-        with:
-          name: ${{ env.cache_key }}
-          path: ${{ env.cache_archive }}
-          # Since this is updated and restored on every run, we don't need to keep it
-          # for long. Just make sure this value is large enough that multiple renovate
-          # runs can happen before older cache archives are deleted.
-          retention-days: 1

--- a/devenv.nix
+++ b/devenv.nix
@@ -3,6 +3,9 @@
 {
   # https://devenv.sh/basics/
   # env.GREET = "devenv";
+  env = {
+    SHELLCHECK_OPTS = "-e SC2002";
+  };
 
   # https://devenv.sh/packages/
   packages = with pkgs; [
@@ -17,7 +20,10 @@
     npm.install.enable = true;
   };
 
-  pre-commit.hooks = { eslint.enable = true; };
+  pre-commit.hooks = {
+    eslint.enable = true;
+    actionlint.enable = true;
+  };
 
   # https://devenv.sh/scripts/
   # scripts.hello.exec = "echo hello from $GREET";
@@ -26,9 +32,6 @@
 
   # https://devenv.sh/languages/
   # languages.nix.enable = true;
-
-  # https://devenv.sh/pre-commit-hooks/
-  # pre-commit.hooks.shellcheck.enable = true;
 
   # https://devenv.sh/processes/
   # processes.ping.exec = "ping example.com";


### PR DESCRIPTION
Since look ups are cached in Redis anyway, I don't think caching the found dependencies will be of much more benefit.

Its not working anyway, and not worth investigating why the copy pasted example is not working.