### PR TITLE
chore: add conform scopes

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -1,25 +1,28 @@
 policies:
-  - type: commit
-    spec:
-      header:
-        length: 89
-        imperative: true
-        case: lower
-        invalidLastCharacters: .
-      body:
-        required: true
-      dco: false
-      gpg:
-        required: true
-      spellcheck:
-        locale: US
-      maximumOfOneCommit: false
-      conventional:
-        types:
-          - feat
-          - fix
-          - chore
-          - deps
-          - docs
-          - ci
-        descriptionLength: 72
+    - type: commit
+      spec:
+          header:
+              length: 89
+              imperative: true
+              case: lower
+              invalidLastCharacters: .
+          body:
+              required: true
+          dco: false
+          gpg:
+              required: true
+          spellcheck:
+              locale: US
+          maximumOfOneCommit: false
+          conventional:
+              scopes:
+                  - master
+                  - deps
+              types:
+                  - feat
+                  - fix
+                  - chore
+                  - deps
+                  - docs
+                  - ci
+              descriptionLength: 72


### PR DESCRIPTION
These 2 scopes are the needed for renovate bot and release please. The rest will be added as needed.