### PR TITLE
fix: use quotation marks for title

### DIFF
--- a/src/template/template.ts
+++ b/src/template/template.ts
@@ -2,7 +2,7 @@ import { BookDetails, ReadStatus } from "../database/interfaces"
 
 export const defaultTemplate = `
 ---
-title: {{Title}}
+title: "{{Title}}"
 author: {{Author}}
 publisher: {{Publisher}}
 dateLastRead: {{DateLastRead}}


### PR DESCRIPTION
Fixes an issue I had where the yaml metadata would break because of a colon in the title.

## Example

Here is how an export of a book I'm reading looks currently:

![image](https://github.com/OGKevin/obsidian-kobo-highlights-import/assets/155654776/cb153f42-1354-4c5b-86e6-81a78c4a9939)

Here's after adding quotation marks to surround the title tag.

![image](https://github.com/OGKevin/obsidian-kobo-highlights-import/assets/155654776/ea13a1be-6438-4286-9893-092962482528)

It could probably be done on other tag contents, like author, publisher etc.

