### PR TITLE
ci: don't run conform on renovate mr's

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -7,6 +7,7 @@ on:
 jobs:
   conform:
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'renovate/')"
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Renovate follows conventional commits, so its fine to skip conform on these.