### PR TITLE
ci: don't run conform on default branch

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,7 +1,5 @@
 name: "pre-commit"
 on:
-  push:
-    branches: ["master"]
   pull_request:
     branches: ["master"]
 jobs:


### PR DESCRIPTION
If a commit reached the default branch, we shall assume it went trough an MR where conform has already been executed.