### PR TITLE
fix: sort highlights by chapter position in book

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ timeSpentReading: <%= it.bookDetails.timeSpentReading ?? '' %>
 
 ## Highlights
 
-<% it.chapters.forEach(([chapterName, highlights]) => { -%>
-## <%= chapterName.trim() %>
+<% it.hierarchicalChapters.forEach((chapter) => { -%>
+<%= '#'.repeat(chapter.depth + 1) %> <%= chapter.title.trim() %>
 
-<% highlights.forEach((highlight) => { -%>
+<% chapter.highlights.forEach((highlight) => { -%>
 <%= highlight.text %>
 
 <% if (highlight.note) { -%>
@@ -72,29 +72,40 @@ timeSpentReading: <%= it.bookDetails.timeSpentReading ?? '' %>
 
 The following variables are available in your template:
 
-| Variable      | Type / Structure                     | Description                                                                                                                                                                                                                                                                                                                    |
-| ------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `bookDetails` | Object                               | Book metadata: <br>`title`, `author`, `publisher`, `dateLastRead`, `readStatus`, `percentRead`, `isbn`, `series`, `seriesNumber`, `timeSpentReading`, `description`                                                                                                                                                            |
-| `chapters`    | Array of `[chapterName, highlights]` | Each `highlights` is an array of bookmarks for that chapter                                                                                                                                                                                                                                                                    |
-| `ReadStatus`  | Enum mapping                         | Maps read status values to their string labels                                                                                                                                                                                                                                                                                 |
-| `highlight`   | Object                               | Each highlight/bookmark:<br>- `bookmarkId`: Unique ID<br>- `text`: The raw highlight text<br>- `contentId`: Content identifier<br>- `note`: Optional note/annotation (if any)<br>- `dateCreated`: [Date](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) when the highlight was created |
+| Variable               | Type / Structure | Description                                                                                                                                                                                                                                                                                                                    |
+| ---------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `bookDetails`          | Object           | Book metadata: <br>`title`, `author`, `publisher`, `dateLastRead`, `readStatus`, `percentRead`, `isbn`, `series`, `seriesNumber`, `timeSpentReading`, `description`                                                                                                                                                            |
+| `hierarchicalChapters` | Array            | Array of chapter objects, each containing: <br>- `title`: Chapter/section name<br>- `depth`: Hierarchical depth level (1 = top-level chapter, 2 = section, 3 = subsection, etc.)<br>- `highlights`: Array of bookmarks for that chapter                                                                                       |
+| `ReadStatus`           | Enum mapping     | Maps read status values to their string labels                                                                                                                                                                                                                                                                                 |
+| `highlight`            | Object           | Each highlight/bookmark:<br>- `bookmarkId`: Unique ID<br>- `text`: The raw highlight text<br>- `contentId`: Content identifier<br>- `note`: Optional note/annotation (if any)<br>- `dateCreated`: [Date](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) when the highlight was created |
 
 #### Example usage
 
 ```eta
-<% it.chapters.forEach(([chapterName, highlights]) => { -%>
-## <%= chapterName %>
-<% highlights.forEach(h => { -%>
+<% it.hierarchicalChapters.forEach((chapter) => { -%>
+<%= '#'.repeat(chapter.depth + 1) %> <%= chapter.title %>
+
+<% chapter.highlights.forEach(h => { -%>
 <%= h.text %>
+
 <% if (h.note) { -%>
 **Note:** <%= h.note %>
+
 <% } -%>
 <% if (h.dateCreated) { -%>
 *Created: <%= h.dateCreated.toISOString() %>*
+
 <% } -%>
 <% }) -%>
 <% }) %>
 ```
+
+The `'#'.repeat(chapter.depth + 1)` generates the appropriate markdown heading level:
+- Depth 1 → `##` (Level 2 heading, since `#` is the book title)
+- Depth 2 → `###` (Level 3 heading for subsections)
+- Depth 3 → `####` (Level 4 heading for sub-subsections)
+
+This preserves the hierarchical structure of your book's table of contents.
 
 #### Date formatting examples
 

--- a/devenv.nix
+++ b/devenv.nix
@@ -12,6 +12,7 @@
     git
     conform
     nodejs
+    sqlite
   ];
 
   languages.javascript = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,6 @@
 			"integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.27.1",
 				"@babel/generator": "^7.28.5",
@@ -1272,7 +1271,8 @@
 			"resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
 			"integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
@@ -1328,7 +1328,6 @@
 			"integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@octokit/auth-token": "^4.0.0",
 				"@octokit/graphql": "^7.1.0",
@@ -1606,7 +1605,6 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.9.tgz",
 			"integrity": "sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"undici-types": "~7.16.0"
 			}
@@ -1727,7 +1725,6 @@
 			"integrity": "sha512-tK3GPFWbirvNgsNKto+UmB/cRtn6TZfyw0D6IKrW55n6Vbs7KJoZtI//kpTKzE/DUmmnAFD8/Ca46s7Obs92/w==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.46.4",
 				"@typescript-eslint/types": "8.46.4",
@@ -2097,7 +2094,6 @@
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -2368,7 +2364,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.8.25",
 				"caniuse-lite": "^1.0.30001754",
@@ -2872,7 +2867,8 @@
 			"resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
 			"integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",
@@ -3254,7 +3250,6 @@
 			"integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -4337,7 +4332,6 @@
 			"integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 10.16.0"
 			}
@@ -6284,7 +6278,8 @@
 			"resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
 			"integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/supports-color": {
 			"version": "7.2.0",
@@ -6501,7 +6496,6 @@
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -6662,7 +6656,8 @@
 			"resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
 			"integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/wabt": {
 			"version": "1.0.39",

--- a/src/database/Highlight.ts
+++ b/src/database/Highlight.ts
@@ -1,8 +1,5 @@
-import { BookDetails, Bookmark, Content, Highlight } from "./interfaces";
+import { BookDetails, Bookmark, Content, Highlight, ChapterWithHighlights } from "./interfaces";
 import { Repository } from "./repository";
-
-type bookTitle = string;
-export type chapter = string;
 
 export class HighlightService {
 	repo: Repository;
@@ -24,36 +21,6 @@ export class HighlightService {
 		}
 
 		return details;
-	}
-
-	convertToMap(arr: Highlight[]): Map<bookTitle, Map<chapter, Bookmark[]>> {
-		const m = new Map<string, Map<string, Bookmark[]>>();
-
-		arr.forEach((x) => {
-			if (!x.content.bookTitle) {
-				throw new Error("bookTitle must be set");
-			}
-
-			const existingBook = m.get(x.content.bookTitle);
-			if (existingBook) {
-				const existingChapter = existingBook.get(x.content.title);
-
-				if (existingChapter) {
-					existingChapter.push(x.bookmark);
-				} else {
-					existingBook.set(x.content.title, [x.bookmark]);
-				}
-			} else {
-				m.set(
-					x.content.bookTitle,
-					new Map<string, Bookmark[]>().set(x.content.title, [
-						x.bookmark,
-					]),
-				);
-			}
-		});
-
-		return m;
 	}
 
 	async getAllHighlight(): Promise<Highlight[]> {
@@ -162,8 +129,54 @@ export class HighlightService {
 		return this.repo.getAllContentByBookTitle(bookTitle);
 	}
 
-	// Create an empty content map for books without highlights
-	createEmptyContentMap(): Map<chapter, Bookmark[]> {
-		return new Map<chapter, Bookmark[]>();
+	/**
+	 * Builds a hierarchical chapter structure for a book by matching highlights to TOC entries.
+	 * The structure preserves the book's table of contents order and depth levels.
+	 * Only chapters with highlights are included in the result.
+	 * 
+	 * @param bookTitle - The title of the book to build hierarchy for
+	 * @param highlights - All highlights, will be filtered to match this book
+	 * @returns Array of chapters with their hierarchical depth and associated highlights
+	 */
+	async buildHierarchicalChapters(bookTitle: string, highlights: Highlight[]): Promise<ChapterWithHighlights[]> {
+		const toc = await this.repo.getTocByBookTitle(bookTitle);
+		const result: ChapterWithHighlights[] = [];
+		
+		const tocMap = new Map<string, Content>();
+		for (const entry of toc) {
+			const strippedId = this.repo.stripContentIdSuffix(entry.contentId);
+			tocMap.set(strippedId, entry);
+		}
+
+		const highlightsByToc = new Map<string, Bookmark[]>();
+		for (const highlight of highlights) {
+			if (highlight.content.bookTitle !== bookTitle) {
+				continue;
+			}
+			
+			const strippedContentId = this.repo.stripContentIdSuffix(highlight.bookmark.contentId);
+			const tocEntry = tocMap.get(strippedContentId);
+			
+			if (tocEntry) {
+				const key = tocEntry.contentId;
+				if (!highlightsByToc.has(key)) {
+					highlightsByToc.set(key, []);
+				}
+				highlightsByToc.get(key)?.push(highlight.bookmark);
+			}
+		}
+
+		for (const tocEntry of toc) {
+			const highlights = highlightsByToc.get(tocEntry.contentId) || [];
+			if (highlights.length > 0) {
+				result.push({
+					title: tocEntry.title,
+					depth: tocEntry.depth || 1,
+					highlights: highlights,
+				});
+			}
+		}
+
+		return result;
 	}
 }

--- a/src/database/Highlight.ts
+++ b/src/database/Highlight.ts
@@ -56,26 +56,15 @@ export class HighlightService {
 		return m;
 	}
 
-	async getAllHighlight(
-		sortByChapterProgress?: boolean,
-	): Promise<Highlight[]> {
+	async getAllHighlight(): Promise<Highlight[]> {
 		const highlights: Highlight[] = [];
 
-		const bookmarks = await this.repo.getAllBookmark(sortByChapterProgress);
+		const bookmarks = await this.repo.getAllBookmark();
 		for (const bookmark of bookmarks) {
 			highlights.push(await this.createHighlightFromBookmark(bookmark));
 		}
 
-		return highlights.sort(function (a, b): number {
-			if (!a.content.bookTitle || !b.content.bookTitle) {
-				throw new Error("bookTitle must be set");
-			}
-
-			return (
-				a.content.bookTitle.localeCompare(b.content.bookTitle) ||
-				a.content.contentId.localeCompare(b.content.contentId)
-			);
-		});
+		return highlights;
 	}
 
 	async createHighlightFromBookmark(bookmark: Bookmark): Promise<Highlight> {

--- a/src/database/interfaces.ts
+++ b/src/database/interfaces.ts
@@ -12,11 +12,18 @@ export interface Content {
 	contentId: string;
 	chapterIdBookmarked?: string;
 	bookTitle?: string;
+	depth?: number;
 }
 
 export interface Highlight {
 	bookmark: Bookmark;
 	content: Content;
+}
+
+export interface ChapterWithHighlights {
+	title: string;
+	depth: number;
+	highlights: Bookmark[];
 }
 
 export interface BookDetails {

--- a/src/database/repository.test.ts
+++ b/src/database/repository.test.ts
@@ -26,6 +26,29 @@ describe("Repository", async function () {
 	it("getAllBookmark", async function () {
 		chai.expect(await repo.getAllBookmark()).length.above(0);
 	});
+
+	it("getAllBookmark should be ordered by FileOffset and ChapterProgress", async function () {
+		const bookmarks = await repo.getAllBookmark();
+		chai.expect(bookmarks).length.above(0);
+
+		const negotiatedMarriageBookmarks = bookmarks.filter((b) =>
+			b.contentId.includes("053b483c-267a-4601-8619-29e619c6e9d3"),
+		);
+
+		if (negotiatedMarriageBookmarks.length >= 2) {
+			const chapterNumbers = negotiatedMarriageBookmarks.map((b) => {
+				const match = b.contentId.match(/!!c(\d+)\.xhtml/);
+				return match ? parseInt(match[1]) : 0;
+			});
+
+			for (let i = 1; i < chapterNumbers.length; i++) {
+				chai.expect(chapterNumbers[i]).to.be.at.least(
+					chapterNumbers[i - 1],
+				);
+			}
+		}
+	});
+
 	it("getBookmarkById null", async function () {
 		chai.expect(await repo.getBookmarkById("")).is.null;
 	});
@@ -56,7 +79,7 @@ describe("Repository", async function () {
 		});
 		chai.expect(
 			await repo.getAllContentByBookTitle(
-				titles.at(Math.floor(Math.random() * titles.length)) ?? "",
+				titles[Math.floor(Math.random() * titles.length)] ?? "",
 			),
 		).length.above(0);
 	});

--- a/src/database/repository.ts
+++ b/src/database/repository.ts
@@ -8,17 +8,20 @@ export class Repository {
 		this.db = db;
 	}
 
-	async getAllBookmark(sortByChapterProgress?: boolean): Promise<Bookmark[]> {
-		let res;
-		if (sortByChapterProgress) {
-			res = this.db.exec(
-				`select BookmarkID, Text, ContentID, annotation, DateCreated, ChapterProgress from Bookmark where Text is not null order by ChapterProgress ASC, DateCreated ASC;`,
-			);
-		} else {
-			res = this.db.exec(
-				`select BookmarkID, Text, ContentID, annotation, DateCreated, ChapterProgress from Bookmark where Text is not null order by DateCreated ASC;`,
-			);
-		}
+	async getAllBookmark(): Promise<Bookmark[]> {
+		const res = this.db.exec(
+			`SELECT 
+				b.BookmarkID, 
+				b.Text, 
+				b.ContentID, 
+				b.annotation, 
+				b.DateCreated, 
+				b.ChapterProgress
+			FROM Bookmark b
+			LEFT JOIN content c ON b.ContentID = c.ContentID
+			WHERE b.Text IS NOT NULL
+			ORDER BY c.BookTitle ASC, c.___FileOffset ASC, b.ChapterProgress ASC;`,
+		);
 		const bookmarks: Bookmark[] = [];
 
 		if (res[0].values == undefined) {

--- a/src/database/repository.ts
+++ b/src/database/repository.ts
@@ -8,25 +8,72 @@ export class Repository {
 		this.db = db;
 	}
 
+	/**
+	 * Extract the depth level from the trailing "-N" suffix of a ContentID.
+	 * E.g. "...xhtml#chapter01_4-2" → 2, "...Cover.xhtml-1" → 1
+	 * Returns 1 if no suffix is found (treat as top-level).
+	 */
+	private extractDepthFromContentId(contentId: string): number {
+		const match = contentId.match(/-(\d+)$/);
+		if (match) {
+			return parseInt(match[1], 10);
+		}
+		return 1;
+	}
+
+	/**
+	 * Strip the trailing "-N" (digits) suffix from a ContentID.
+	 * E.g. "...xhtml#chapter01_4-2" → "...xhtml#chapter01_4"
+	 *       "...Cover.xhtml-1"      → "...Cover.xhtml"
+	 */
+	stripContentIdSuffix(contentId: string): string {
+		const match = contentId.match(/^(.+)-(\d+)$/);
+		if (match) {
+			return match[1];
+		}
+		return contentId;
+	}
+
+	/**
+	 * Retrieves all bookmarks with their associated content metadata.
+	 * Bookmarks are matched to content entries by stripping the TOC suffix from ContentIDs.
+	 * Results are ordered by book title, TOC content ID, and chapter progress.
+	 * 
+	 * @returns Array of all bookmarks with text content
+	 */
 	async getAllBookmark(): Promise<Bookmark[]> {
 		const res = this.db.exec(
-			`SELECT 
+			`SELECT DISTINCT
 				b.BookmarkID, 
 				b.Text, 
 				b.ContentID, 
 				b.annotation, 
 				b.DateCreated, 
-				b.ChapterProgress
+				b.ChapterProgress,
+				MIN(CASE WHEN c.ContentType = '899' THEN 0 WHEN c.ContentType = '9' THEN 1 ELSE 2 END) as Priority,
+				MAX(c.BookTitle) as BookTitle,
+				MAX(CASE WHEN c.ContentType = '899' THEN c.ContentID ELSE NULL END) as TOCContentID
 			FROM Bookmark b
-			LEFT JOIN content c ON b.ContentID = c.ContentID
+			LEFT JOIN (
+				SELECT ContentID, 
+					CASE 
+						WHEN ContentID GLOB '*-[0-9]' THEN SUBSTR(ContentID, 1, LENGTH(ContentID) - 2)
+						WHEN ContentID GLOB '*-[0-9][0-9]' THEN SUBSTR(ContentID, 1, LENGTH(ContentID) - 3)
+						ELSE ContentID 
+					END AS MatchID,
+					BookTitle,
+					ContentType
+				FROM content
+			) c ON b.ContentID = c.ContentID OR b.ContentID = c.MatchID
 			WHERE b.Text IS NOT NULL
-			ORDER BY c.BookTitle ASC, c.___FileOffset ASC, b.ChapterProgress ASC;`,
+			GROUP BY b.BookmarkID
+			ORDER BY BookTitle ASC, COALESCE(TOCContentID, b.ContentID) ASC, b.ChapterProgress ASC;`,
 		);
 		const bookmarks: Bookmark[] = [];
 
 		if (res[0].values == undefined) {
 			console.warn(
-				"Bookmarks table returend no results, do you have any annotations created?",
+				"Bookmarks table returned no results, do you have any annotations created?",
 			);
 
 			return bookmarks;
@@ -97,16 +144,27 @@ export class Repository {
 		const statement = this.db.prepare(
 			`select 
                 Title, ContentID, ChapterIDBookmarked, BookTitle from content
-                where ContentID = $id;`,
+                where ContentID = $id
+                OR (CASE 
+                    WHEN ContentID GLOB '*-[0-9]' THEN SUBSTR(ContentID, 1, LENGTH(ContentID) - 2)
+                    WHEN ContentID GLOB '*-[0-9][0-9]' THEN SUBSTR(ContentID, 1, LENGTH(ContentID) - 3)
+                    ELSE ContentID 
+                END) = $id;`,
 			{ $id: contentId },
 		);
 		const contents = this.parseContentStatement(statement);
 		statement.free();
 
 		if (contents.length > 1) {
-			throw new Error(
-				"filtering by contentId yielded more then 1 result",
+			console.warn(
+				`filtering by contentId yielded more then 1 result: ${contentId}, using the first result with ChapterIDBookmarked.`,
 			);
+			const preferred = contents.find(
+				(c) => c.chapterIdBookmarked != null,
+			);
+			if (preferred) {
+				return preferred;
+			}
 		}
 
 		return contents.pop() || null;
@@ -159,6 +217,30 @@ export class Repository {
 	async getAllContentByBookTitle(bookTitle: string): Promise<Content[]> {
 		const statement = this.db.prepare(
 			`select Title, ContentID, ChapterIDBookmarked, BookTitle  from "content" where BookTitle = $bookTitle`,
+			{ $bookTitle: bookTitle },
+		);
+
+		const contents = this.parseContentStatement(statement);
+		statement.free();
+
+		return contents;
+	}
+
+	/**
+	 * Retrieves the Table of Contents (TOC) entries for a specific book.
+	 * Only fetches ContentType 899 entries which represent the hierarchical TOC structure.
+	 * Results are ordered by VolumeIndex to preserve the book's chapter order.
+	 * 
+	 * @param bookTitle - The title of the book to fetch TOC for
+	 * @returns Array of TOC content entries with depth information
+	 */
+	async getTocByBookTitle(bookTitle: string): Promise<Content[]> {
+		const statement = this.db.prepare(
+			`select Title, ContentID, ChapterIDBookmarked, BookTitle 
+			 from "content" 
+			 where BookTitle = $bookTitle 
+			 AND ContentType = '899'
+			 order by VolumeIndex`,
 			{ $bookTitle: bookTitle },
 		);
 
@@ -274,11 +356,13 @@ export class Repository {
 
 		while (statement.step()) {
 			const row = statement.get();
+			const contentId = row[1]?.toString() ?? "";
 			contents.push({
 				title: row[0]?.toString() ?? "",
-				contentId: row[1]?.toString() ?? "",
+				contentId: contentId,
 				chapterIdBookmarked: row[2]?.toString(),
 				bookTitle: row[3]?.toString(),
+				depth: this.extractDepthFromContentId(contentId),
 			});
 		}
 

--- a/src/modal/ExtractHighlightsModal.ts
+++ b/src/modal/ExtractHighlightsModal.ts
@@ -40,9 +40,7 @@ export class ExtractHighlightsModal extends Modal {
 			new Repository(db),
 		);
 
-		const content = service.convertToMap(
-			await service.getAllHighlight(this.settings.sortByChapterProgress),
-		);
+		const content = service.convertToMap(await service.getAllHighlight());
 
 		const allBooksContent = new Map<string, Map<string, Bookmark[]>>();
 

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -5,14 +5,12 @@ import { FolderSuggestor } from "./suggestors/FolderSuggestor";
 
 export const DEFAULT_SETTINGS: KoboHighlightsImporterSettings = {
 	storageFolder: "",
-	sortByChapterProgress: false,
 	templatePath: "",
 	importAllBooks: false,
 };
 
 export interface KoboHighlightsImporterSettings {
 	storageFolder: string;
-	sortByChapterProgress: boolean;
 	templatePath: string;
 	importAllBooks: boolean;
 }
@@ -31,7 +29,6 @@ export class KoboHighlightsImporterSettingsTab extends PluginSettingTab {
 
 		this.add_destination_folder();
 		this.add_template_path();
-		this.add_sort_by_chapter_progress();
 		this.add_import_all_books();
 	}
 
@@ -62,25 +59,6 @@ export class KoboHighlightsImporterSettingsTab extends PluginSettingTab {
 						this.plugin.settings.templatePath = newTemplatePath;
 						this.plugin.saveSettings();
 					});
-			});
-	}
-
-	add_sort_by_chapter_progress(): void {
-		const desc = document.createDocumentFragment();
-		desc.append(
-			"Turn on to sort highlights by chapter progess. If turned off, highlights are sorted by creation date and time.",
-		);
-
-		new Setting(this.containerEl)
-			.setName("Sort by chapter progress")
-			.setDesc(desc)
-			.addToggle((cb) => {
-				cb.setValue(
-					this.plugin.settings.sortByChapterProgress,
-				).onChange((toggle) => {
-					this.plugin.settings.sortByChapterProgress = toggle;
-					this.plugin.saveSettings();
-				});
 			});
 	}
 

--- a/src/template/template.test.ts
+++ b/src/template/template.test.ts
@@ -1,14 +1,14 @@
 import * as chai from "chai";
 import { applyTemplateTransformations, defaultTemplate } from "./template";
-import { chapter } from "../database/Highlight";
-import { Bookmark } from "../database/interfaces";
+import { ChapterWithHighlights } from "../database/interfaces";
 
 describe("template", async function () {
 	const testDate = new Date("2023-01-01T12:00:00Z");
-	const chapters = new Map<chapter, Bookmark[]>([
-		[
-			"Chapter 1",
-			[
+	const chapters: ChapterWithHighlights[] = [
+		{
+			title: "Chapter 1",
+			depth: 1,
+			highlights: [
 				{
 					bookmarkId: "1",
 					text: "test",
@@ -16,11 +16,11 @@ describe("template", async function () {
 					dateCreated: testDate,
 				},
 			],
-		],
-
-		[
-			"Chapter 2",
-			[
+		},
+		{
+			title: "Chapter 2",
+			depth: 1,
+			highlights: [
 				{
 					bookmarkId: "1",
 					text: "test2",
@@ -29,8 +29,8 @@ describe("template", async function () {
 					note: "note2",
 				},
 			],
-		],
-	]);
+		},
+	];
 
 	function normalize(s: string) {
 		return s
@@ -141,8 +141,8 @@ title: <%= it.bookDetails.title %>
 ---
 # <%= it.bookDetails.title %>
 
-<% it.chapters.forEach(([chapterName, highlights]) => { %>
-<%- highlights.forEach(h => { -%>
+<% it.hierarchicalChapters.forEach((chapter) => { %>
+<%- chapter.highlights.forEach(h => { -%>
 <%= h.text %>
 <% }) %>
 <% }) %>`,
@@ -168,10 +168,10 @@ title: "<%= it.bookDetails.title %>"
 
 # <%= it.bookDetails.title %>
 
-<% it.chapters.forEach(([chapterName, highlights]) => { -%>
-## <%= chapterName %>
+<% it.hierarchicalChapters.forEach((chapter) => { -%>
+<%= '#'.repeat(chapter.depth + 1) %> <%= chapter.title %>
 
-<% highlights.forEach(h => { -%>
+<% chapter.highlights.forEach(h => { -%>
 <%= h.text %>
 
 *Created: <%= h.dateCreated.getFullYear() %>-<%= String(h.dateCreated.getMonth() + 1).padStart(2, '0') %>-<%= String(h.dateCreated.getDate()).padStart(2, '0') %>*

--- a/src/template/template.ts
+++ b/src/template/template.ts
@@ -1,6 +1,5 @@
 import { Eta } from "eta";
-import { BookDetails, ReadStatus, Bookmark } from "../database/interfaces";
-import { chapter } from "../database/Highlight";
+import { BookDetails, ReadStatus, ChapterWithHighlights } from "../database/interfaces";
 
 const eta = new Eta({ autoEscape: false, autoTrim: false });
 
@@ -26,10 +25,10 @@ timeSpentReading: <%= it.bookDetails.timeSpentReading ?? '' %>
 
 ## Highlights
 
-<% it.chapters.forEach(([chapterName, highlights]) => { -%>
-## <%= chapterName.trim() %>
+<% it.hierarchicalChapters.forEach((chapter) => { -%>
+<%= '#'.repeat(chapter.depth + 1) %> <%= chapter.title.trim() %>
 
-<% highlights.forEach((highlight) => { -%>
+<% chapter.highlights.forEach((highlight) => { -%>
 <%= highlight.text %>
 
 <% if (highlight.note) { -%>
@@ -46,13 +45,12 @@ timeSpentReading: <%= it.bookDetails.timeSpentReading ?? '' %>
 
 export function applyTemplateTransformations(
 	rawTemplate: string,
-	chapters: Map<chapter, Bookmark[]>,
+	hierarchicalChapters: ChapterWithHighlights[],
 	bookDetails: BookDetails,
 ): string {
-	const chaptersArr = Array.from(chapters.entries());
 	const rendered = eta.renderString(rawTemplate, {
 		bookDetails,
-		chapters: chaptersArr,
+		hierarchicalChapters,
 		ReadStatus,
 	});
 
@@ -66,3 +64,5 @@ export function applyTemplateTransformations(
 
 	return rendered.trim();
 }
+
+export const applyHierarchicalTemplateTransformations = applyTemplateTransformations;


### PR DESCRIPTION
Fix incorrect ordering where chapters appeared alphabetically (e.g., Chapter 11 before Chapter 2) instead of by reading order. Use ___FileOffset from content table to determine chapter position, following the approach used in kobo.koplugin.

- Replace alphabetical ContentID sort with ___FileOffset-based ordering via SQL JOIN
- Remove JavaScript post-fetch sort that was overriding database ordering
- Remove sortByChapterProgress setting (now always correct)
- Add test to verify bookmarks are ordered by FileOffset and ChapterProgress
- Update getAllBookmark to ORDER BY BookTitle, ___FileOffset, ChapterProgress

Change-Id: faa008a904e2cf58f9c72c60d4e0e436
Change-Id-Short: kppzzrpqzvlx