### PR TITLE
Fix: Sort highlights by chapter position in book

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,6 +76,7 @@
 			"integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.27.1",
 				"@babel/generator": "^7.28.5",
@@ -1271,8 +1272,7 @@
 			"resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
 			"integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
@@ -1328,6 +1328,7 @@
 			"integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@octokit/auth-token": "^4.0.0",
 				"@octokit/graphql": "^7.1.0",
@@ -1605,6 +1606,7 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.9.tgz",
 			"integrity": "sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"undici-types": "~7.16.0"
 			}
@@ -1725,6 +1727,7 @@
 			"integrity": "sha512-tK3GPFWbirvNgsNKto+UmB/cRtn6TZfyw0D6IKrW55n6Vbs7KJoZtI//kpTKzE/DUmmnAFD8/Ca46s7Obs92/w==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.46.4",
 				"@typescript-eslint/types": "8.46.4",
@@ -2094,6 +2097,7 @@
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -2364,6 +2368,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.8.25",
 				"caniuse-lite": "^1.0.30001754",
@@ -2867,8 +2872,7 @@
 			"resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
 			"integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",
@@ -3250,6 +3254,7 @@
 			"integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -4332,6 +4337,7 @@
 			"integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">= 10.16.0"
 			}
@@ -6278,8 +6284,7 @@
 			"resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
 			"integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/supports-color": {
 			"version": "7.2.0",
@@ -6496,6 +6501,7 @@
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -6656,8 +6662,7 @@
 			"resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
 			"integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/wabt": {
 			"version": "1.0.39",

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,6 @@
 			"integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.27.1",
 				"@babel/generator": "^7.28.5",
@@ -1272,7 +1271,8 @@
 			"resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
 			"integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
@@ -1328,7 +1328,6 @@
 			"integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@octokit/auth-token": "^4.0.0",
 				"@octokit/graphql": "^7.1.0",
@@ -1606,7 +1605,6 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.9.tgz",
 			"integrity": "sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"undici-types": "~7.16.0"
 			}
@@ -1727,7 +1725,6 @@
 			"integrity": "sha512-tK3GPFWbirvNgsNKto+UmB/cRtn6TZfyw0D6IKrW55n6Vbs7KJoZtI//kpTKzE/DUmmnAFD8/Ca46s7Obs92/w==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.46.4",
 				"@typescript-eslint/types": "8.46.4",
@@ -2097,7 +2094,6 @@
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -2368,7 +2364,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.8.25",
 				"caniuse-lite": "^1.0.30001754",
@@ -2872,7 +2867,8 @@
 			"resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
 			"integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",
@@ -3254,7 +3250,6 @@
 			"integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -4337,7 +4332,6 @@
 			"integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 10.16.0"
 			}
@@ -6284,7 +6278,8 @@
 			"resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
 			"integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/supports-color": {
 			"version": "7.2.0",
@@ -6501,7 +6496,6 @@
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -6662,7 +6656,8 @@
 			"resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
 			"integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/wabt": {
 			"version": "1.0.39",

--- a/src/database/Highlight.test.ts
+++ b/src/database/Highlight.test.ts
@@ -1,314 +1,63 @@
-import { expect, assert } from "chai";
-import { v4 as uuidv4 } from "uuid";
+import { expect } from "chai";
 import { HighlightService } from "./Highlight";
-import { Bookmark, Content, Highlight } from "./interfaces";
-import { Repository } from "./repository";
+import { Bookmark } from "./interfaces";
+import { Repository, stripSuffix, extractDepth } from "./repository";
 
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 
+describe("stripSuffix", function () {
+	it("removes trailing digits after dash", function () {
+		expect(stripSuffix("book.epub!OPS!xhtml/Chapter01.xhtml#chapter01_4-2")).to.equal(
+			"book.epub!OPS!xhtml/Chapter01.xhtml#chapter01_4",
+		);
+	});
+
+	it("removes single digit suffix", function () {
+		expect(stripSuffix("book.epub!OPS!xhtml/Cover.xhtml-1")).to.equal(
+			"book.epub!OPS!xhtml/Cover.xhtml",
+		);
+	});
+
+	it("leaves string unchanged when no suffix", function () {
+		expect(stripSuffix("book.epub!OPS!xhtml/Chapter01.xhtml#chapter01_4")).to.equal(
+			"book.epub!OPS!xhtml/Chapter01.xhtml#chapter01_4",
+		);
+	});
+
+	it("leaves string unchanged when dash not followed by digits", function () {
+		expect(stripSuffix("some-path/file.xhtml#section-abc")).to.equal(
+			"some-path/file.xhtml#section-abc",
+		);
+	});
+
+	it("handles empty string", function () {
+		expect(stripSuffix("")).to.equal("");
+	});
+});
+
+describe("extractDepth", function () {
+	it("extracts single digit depth", function () {
+		expect(extractDepth("book.epub!xhtml/Cover.xhtml-1")).to.equal(1);
+	});
+
+	it("extracts multi-digit depth", function () {
+		expect(extractDepth("book.epub!xhtml/Chapter01.xhtml#ch01_4-2")).to.equal(2);
+	});
+
+	it("extracts deep level", function () {
+		expect(extractDepth("book.epub!Text/wahl.html#sigil_toc_id_6-4")).to.equal(4);
+	});
+
+	it("defaults to 1 when no suffix", function () {
+		expect(extractDepth("book.epub!xhtml/Chapter01.xhtml#ch01_4")).to.equal(1);
+	});
+
+	it("defaults to 1 when dash not followed by digits", function () {
+		expect(extractDepth("some-path/file.xhtml#section-abc")).to.equal(1);
+	});
+});
+
 describe("HighlightService", async function () {
-	describe("Sample Content", async function () {
-		let service: HighlightService;
-
-		before(async function () {
-			const repo = {} as Repository;
-			repo.getContentByContentId = () =>
-				Promise.resolve({
-					title: "Chapter Eight: Holden",
-					contentId:
-						"file:///mnt/onboard/Corey, James S.A_/Nemesis Games - James S.A. Corey.epub#(12)OEBPS/Text/ch09.html",
-					bookTitle: "Nemesis Games",
-					chapterIdBookmarked: "true",
-				});
-			service = new HighlightService(repo);
-		});
-
-		describe("Sample Bookmark with no annotation", async function () {
-			let highlight: Highlight;
-
-			before(async function () {
-				const dateCreated = new Date(
-					Date.UTC(2022, 7, 5, 20, 46, 41, 0),
-				);
-				const bookmark: Bookmark = {
-					bookmarkId: "c5b2637d-ddaf-4f15-9a81-dd701e0ad8fe",
-					text: "“I guess I can’t be. How do you prove a negative?”",
-					contentId:
-						"file:///mnt/onboard/Corey, James S.A_/Nemesis Games - James S.A. Corey.epub#(12)OEBPS/Text/ch09.html",
-					note: "",
-					dateCreated,
-				};
-				highlight = await service.createHighlightFromBookmark(bookmark);
-			});
-
-			it("createHighlightFromBookmark", async function () {
-				const dateCreated = new Date(
-					Date.UTC(2022, 7, 5, 20, 46, 41, 0),
-				);
-				const bookmark: Bookmark = {
-					bookmarkId: "c5b2637d-ddaf-4f15-9a81-dd701e0ad8fe",
-					text: "“I guess I can’t be. How do you prove a negative?”",
-					contentId:
-						"file:///mnt/onboard/Corey, James S.A_/Nemesis Games - James S.A. Corey.epub#(12)OEBPS/Text/ch09.html",
-					note: "",
-					dateCreated,
-				};
-				highlight = await service.createHighlightFromBookmark(bookmark);
-
-				assert.deepEqual(highlight, {
-					content: {
-						title: "Chapter Eight: Holden",
-						contentId:
-							"file:///mnt/onboard/Corey, James S.A_/Nemesis Games - James S.A. Corey.epub#(12)OEBPS/Text/ch09.html",
-						bookTitle: "Nemesis Games",
-						chapterIdBookmarked: "true",
-					},
-					bookmark: {
-						bookmarkId: "c5b2637d-ddaf-4f15-9a81-dd701e0ad8fe",
-						text: "“I guess I can’t be. How do you prove a negative?”",
-						contentId:
-							"file:///mnt/onboard/Corey, James S.A_/Nemesis Games - James S.A. Corey.epub#(12)OEBPS/Text/ch09.html",
-						note: "",
-						dateCreated,
-					},
-				});
-			});
-
-			it("convertToMap creates correct structure", async function () {
-				const map = service.convertToMap([highlight]);
-
-				expect(map.size).to.equal(1);
-				expect(map.has("Nemesis Games")).to.be.true;
-
-				const bookMap = map.get("Nemesis Games");
-				expect(bookMap?.size).to.equal(1);
-				expect(bookMap?.has("Chapter Eight: Holden")).to.be.true;
-
-				const highlights = bookMap?.get("Chapter Eight: Holden");
-				expect(highlights).to.have.length(1);
-				expect(highlights?.[0].bookmarkId).to.equal(
-					"c5b2637d-ddaf-4f15-9a81-dd701e0ad8fe",
-				);
-			});
-		});
-
-		describe("Sample Bookmark with annotation", async function () {
-			let highlight: Highlight;
-
-			before(async function () {
-				const dateCreated = new Date(
-					Date.UTC(2022, 7, 5, 20, 46, 41, 0),
-				);
-				const bookmark: Bookmark = {
-					bookmarkId: "c5b2637d-ddaf-4f15-9a81-dd701e0ad8fe",
-					text: "“I guess I can’t be. How do you prove a negative?”",
-					contentId:
-						"file:///mnt/onboard/Corey, James S.A_/Nemesis Games - James S.A. Corey.epub#(12)OEBPS/Text/ch09.html",
-					note: "This is a great note!",
-					dateCreated,
-				};
-				highlight = await service.createHighlightFromBookmark(bookmark);
-			});
-
-			it("createHighlightFromBookmark", async function () {
-				const dateCreated = new Date(
-					Date.UTC(2022, 7, 5, 20, 46, 41, 0),
-				);
-				const bookmark: Bookmark = {
-					bookmarkId: "c5b2637d-ddaf-4f15-9a81-dd701e0ad8fe",
-					text: "“I guess I can’t be. How do you prove a negative?”",
-					contentId:
-						"file:///mnt/onboard/Corey, James S.A_/Nemesis Games - James S.A. Corey.epub#(12)OEBPS/Text/ch09.html",
-					note: "This is a great note!",
-					dateCreated,
-				};
-				highlight = await service.createHighlightFromBookmark(bookmark);
-
-				assert.deepEqual(highlight, {
-					content: {
-						title: "Chapter Eight: Holden",
-						contentId:
-							"file:///mnt/onboard/Corey, James S.A_/Nemesis Games - James S.A. Corey.epub#(12)OEBPS/Text/ch09.html",
-						bookTitle: "Nemesis Games",
-						chapterIdBookmarked: "true",
-					},
-					bookmark: {
-						bookmarkId: "c5b2637d-ddaf-4f15-9a81-dd701e0ad8fe",
-						text: "“I guess I can’t be. How do you prove a negative?”",
-						contentId:
-							"file:///mnt/onboard/Corey, James S.A_/Nemesis Games - James S.A. Corey.epub#(12)OEBPS/Text/ch09.html",
-						note: "This is a great note!",
-						dateCreated,
-					},
-				});
-			});
-		});
-	});
-
-	describe("Sample Content Missing", async function () {
-		let service: HighlightService;
-
-		before(async function () {
-			const repo = {} as Repository;
-			repo.getContentByContentId = () => Promise.resolve(null);
-			repo.getContentLikeContentId = () => Promise.resolve(null);
-			service = new HighlightService(repo);
-		});
-
-		describe("Sample Bookmark linked to missing content", async function () {
-			let highlight: Highlight;
-
-			before(async function () {
-				const dateCreated = new Date(
-					Date.UTC(2022, 7, 5, 20, 46, 41, 0),
-				);
-				const bookmarkID = uuidv4();
-				const bookmark: Bookmark = {
-					bookmarkId: bookmarkID,
-					text: "“I guess I can’t be. How do you prove a negative?”",
-					contentId: "missing-content-id",
-					note: "",
-					dateCreated,
-				};
-				highlight = await service.createHighlightFromBookmark(bookmark);
-			});
-
-			it("createHighlightFromBookmark with missing content", async function () {
-				expect(highlight.content.bookTitle).to.equal("Unknown Title");
-				expect(highlight.content.title).to.equal("Unknown Title");
-				expect(highlight.bookmark.bookmarkId).to.not.be.empty;
-			});
-		});
-	});
-
-	describe("with multiple content", async function () {
-		const contentMap = new Map<string, Content>([
-			[
-				"e7f8f92d-38ca-4556-bab8-a4d902e9c430",
-				{
-					title: "Chapter Eight: Holden",
-					contentId:
-						"file:///mnt/onboard/Corey, James S.A_/Nemesis Games - James S.A. Corey.epub#(12)OEBPS/Text/ch09.html",
-					bookTitle: "Nemesis Games",
-					chapterIdBookmarked:
-						"e7f8f92d-38ca-4556-bab8-a4d902e9c430!Text/chapter002.xhtml",
-				},
-			],
-			[
-				"d40c9071-993f-4f1f-ae53-594847d9fd27",
-				{
-					title: "On Passwords and Power Drills",
-					contentId:
-						"/mnt/onboard/Adkins, Heather & Beyer, Betsy & Blankiotr & Oprea, Ana & Stubblefield, Adam/Building Secure and Reliable Systems_ Best PractiLewandowski & Ana Oprea & Adam Stubblefield.kepub.epub!!OEBPS/ch01.html#on_passwords_and_power_drills-2",
-					bookTitle:
-						"Building Secure and Reliable Systems: Best Practices for Designing, Implementing, and Maintaining Systems",
-					chapterIdBookmarked:
-						"/mnt/onboard/Adkins, Heather & Beyer, Betsy & Blankiotr & Oprea, Ana & Stubblefield, Adam/Building Secure and Reliable Systems_ Best PractiLewandowski & Ana Oprea & Adam Stubblefield.kepub.epub!!OEBPS/ch01.html",
-				},
-			],
-			[
-				"3408844d-65a6-4d23-9d99-8f189ca07d0b",
-				{
-					title: "Dune",
-					contentId:
-						"23ba3dcf-3543-476c-984b-2f746c859763!OEBPS!Text/chapter001.xhtml-1",
-					bookTitle: "Dune",
-					chapterIdBookmarked:
-						"23ba3dcf-3543-476c-984b-2f746c859763!OEBPS!Text/chapter001.xhtml",
-				},
-			],
-			[
-				"c0d92aca-e4bb-476a-8131-ee0c0c21ced5",
-				{
-					title: "11. Being On-Call",
-					contentId:
-						"bce81485-5e92-4cca-8965-613c3ca12737!OEBPS!ch11.html#chapter_oncall-engineer-1",
-					bookTitle: "Site Reliability Engineering",
-					chapterIdBookmarked:
-						"bce81485-5e92-4cca-8965-613c3ca12737!OEBPS!ch11.html",
-				},
-			],
-		]);
-
-		const bookmarkMap = new Map<string, Bookmark>([
-			[
-				"e7f8f92d-38ca-4556-bab8-a4d902e9c430",
-				{
-					text: "“I guess I can’t be. How do you prove a negative?”",
-					contentId: "e7f8f92d-38ca-4556-bab8-a4d902e9c430",
-					note: "",
-					dateCreated: new Date("2022-08-05T20:46:41+00:00"),
-				} as Bookmark,
-			],
-			[
-				"d40c9071-993f-4f1f-ae53-594847d9fd27",
-				{
-					text: "“I guess I can’t be. How do you prove a negative?”",
-					contentId: "d40c9071-993f-4f1f-ae53-594847d9fd27",
-					note: "",
-					dateCreated: new Date("2022-08-05T20:46:41+00:00"),
-				} as Bookmark,
-			],
-			[
-				"3408844d-65a6-4d23-9d99-8f189ca07d0b",
-				{
-					text: "“I guess I can’t be. How do you prove a negative?”",
-					contentId: "3408844d-65a6-4d23-9d99-8f189ca07d0b",
-					note: "",
-					dateCreated: new Date("2022-08-05T20:46:41+00:00"),
-				} as Bookmark,
-			],
-			[
-				"c0d92aca-e4bb-476a-8131-ee0c0c21ced5",
-				{
-					text: "“I guess I can’t be. How do you prove a negative?”",
-					contentId: "c0d92aca-e4bb-476a-8131-ee0c0c21ced5",
-					note: "",
-					dateCreated: new Date("2022-08-05T20:46:41+00:00"),
-				} as Bookmark,
-			],
-		]);
-
-		let repo: Repository;
-		let service: HighlightService;
-
-		before(async function () {
-			repo = {} as Repository;
-			repo.getContentByContentId = (contentId) =>
-				Promise.resolve(contentMap.get(contentId) ?? null);
-			repo.getTotalBookmark = () => Promise.resolve(contentMap.size);
-			const bookmarks = new Array<Bookmark>();
-			bookmarkMap.forEach((entry) => bookmarks.push(entry));
-			repo.getAllBookmark = () => Promise.resolve(bookmarks);
-			repo.getBookmarkById = (bookmarkId) =>
-				Promise.resolve(bookmarkMap.get(bookmarkId) ?? null);
-			service = new HighlightService(repo);
-		});
-
-		it("getAllHighlight", async function () {
-			const all = await service.getAllHighlight();
-			const total = await repo.getTotalBookmark();
-			expect(all).length(total);
-		});
-
-		for (const [id, content] of contentMap) {
-			it(`createHighlightFromBookmark ${id}`, async function () {
-				const bookmark = await repo.getBookmarkById(id);
-				if (!bookmark) {
-					assert.isNotNull(bookmark);
-					return;
-				}
-
-				const highlight =
-					await service.createHighlightFromBookmark(bookmark);
-				assert.deepEqual(highlight, {
-					content: content,
-					bookmark: bookmark,
-				});
-			});
-		}
-	});
-
 	describe("Import All Books", async function () {
 		let service: HighlightService;
 		let repo: Repository;
@@ -351,23 +100,6 @@ describe("HighlightService", async function () {
 				);
 				return Promise.resolve(details || null);
 			};
-			repo.getAllBookmark = () =>
-				Promise.resolve([
-					{
-						bookmarkId: "bookmark1",
-						text: "Sample highlight",
-						contentId: "content1",
-						note: "Test note",
-						dateCreated: new Date("2024-01-01"),
-					},
-				]);
-			repo.getContentByContentId = () =>
-				Promise.resolve({
-					title: "Chapter 1",
-					contentId: "content1",
-					bookTitle: "Book with Highlights",
-					chapterIdBookmarked: "chapter1",
-				});
 
 			service = new HighlightService(repo);
 		});
@@ -386,36 +118,6 @@ describe("HighlightService", async function () {
 			expect(bookWithHighlights?.percentRead).to.equal(100);
 			expect(bookWithoutHighlights?.author).to.equal("Author 2");
 			expect(bookWithoutHighlights?.percentRead).to.equal(50);
-		});
-
-		it("convertToMap should handle books with and without highlights correctly", async function () {
-			const highlights = await service.getAllHighlight();
-			const contentMap = service.convertToMap(highlights);
-
-			// Verify initial state with only books containing highlights
-			expect(contentMap.size).to.equal(1);
-			expect(contentMap.has("Book with Highlights")).to.be.true;
-			expect(contentMap.has("Book without Highlights")).to.be.false;
-
-			// Add books without highlights
-			const allBooks = await service.getAllBooks();
-			for (const [bookTitle, _] of allBooks) {
-				if (!contentMap.has(bookTitle)) {
-					contentMap.set(bookTitle, service.createEmptyContentMap());
-				}
-			}
-
-			// Verify final state with all books
-			expect(contentMap.size).to.equal(2);
-
-			const bookWithHighlights = contentMap.get("Book with Highlights");
-			const bookWithoutHighlights = contentMap.get(
-				"Book without Highlights",
-			);
-
-			expect(bookWithHighlights).to.not.be.undefined;
-			expect(bookWithoutHighlights).to.not.be.undefined;
-			expect(bookWithoutHighlights?.size).to.equal(0);
 		});
 
 		it("getBookDetailsFromBookTitle should return correct book details", async function () {
@@ -447,6 +149,189 @@ describe("HighlightService", async function () {
 				title: "Unknown Title",
 				author: "Unknown Author",
 			});
+		});
+	});
+
+	describe("buildBookHighlightMap", async function () {
+		it("matches bookmarks to TOC entries via stripped suffix", async function () {
+			const repo = {} as Repository;
+			repo.getBookTitleByContentId = () =>
+				Promise.resolve("The Starlight Archive");
+			repo.getTocEntriesByBookId = () =>
+				Promise.resolve([
+					{
+						title: "Part One: The Voyage",
+						contentId: "book!ch01.xhtml#part1-1",
+						matchId: "book!ch01.xhtml#part1",
+						depth: 1,
+						volumeIndex: 0,
+					},
+					{
+						title: "1. The Departure",
+						contentId: "book!ch01.xhtml#sec1-2",
+						matchId: "book!ch01.xhtml#sec1",
+						depth: 2,
+						volumeIndex: 1,
+					},
+					{
+						title: "2. The Storm",
+						contentId: "book!ch01.xhtml#sec2-2",
+						matchId: "book!ch01.xhtml#sec2",
+						depth: 2,
+						volumeIndex: 2,
+					},
+				]);
+
+			const service = new HighlightService(repo);
+			const bookmarks: Bookmark[] = [
+				{
+					bookmarkId: "bm1",
+					text: "A passage about stars",
+					contentId: "book!ch01.xhtml#sec1",
+					volumeId: "book-volume",
+					dateCreated: new Date("2024-01-01"),
+				},
+			];
+
+			const result = await service.buildBookHighlightMap(bookmarks);
+
+			expect(result.size).to.equal(1);
+			const chapters = result.get("The Starlight Archive");
+			expect(chapters).to.not.be.undefined;
+			expect(chapters).to.have.length(2);
+
+			// Part One emitted as ancestor
+			expect(chapters![0].title).to.equal("Part One: The Voyage");
+			expect(chapters![0].depth).to.equal(1);
+			expect(chapters![0].highlights).to.have.length(0);
+
+			// Section 1 with the highlight
+			expect(chapters![1].title).to.equal("1. The Departure");
+			expect(chapters![1].depth).to.equal(2);
+			expect(chapters![1].highlights).to.have.length(1);
+		});
+
+		it("puts unmatched bookmarks in Uncategorized", async function () {
+			const repo = {} as Repository;
+			repo.getBookTitleByContentId = () =>
+				Promise.resolve("The Starlight Archive");
+			repo.getTocEntriesByBookId = () =>
+				Promise.resolve([
+					{
+						title: "Chapter One",
+						contentId: "book!ch01.xhtml-1",
+						matchId: "book!ch01.xhtml",
+						depth: 1,
+						volumeIndex: 0,
+					},
+				]);
+
+			const service = new HighlightService(repo);
+			const bookmarks: Bookmark[] = [
+				{
+					bookmarkId: "bm1",
+					text: "An unmatched passage",
+					contentId: "book!unknown.xhtml#x",
+					volumeId: "book-volume",
+					dateCreated: new Date("2024-01-01"),
+				},
+			];
+
+			const result = await service.buildBookHighlightMap(bookmarks);
+			const chapters = result.get("The Starlight Archive")!;
+
+			const uncategorized = chapters.find(
+				(c) => c.title === "Uncategorized",
+			);
+			expect(uncategorized).to.not.be.undefined;
+			expect(uncategorized!.highlights).to.have.length(1);
+		});
+
+		it("falls back to Uncategorized when no 899 entries exist", async function () {
+			const repo = {} as Repository;
+			repo.getBookTitleByContentId = () =>
+				Promise.resolve("The Starlight Archive");
+			repo.getTocEntriesByBookId = () => Promise.resolve([]);
+
+			const service = new HighlightService(repo);
+			const bookmarks: Bookmark[] = [
+				{
+					bookmarkId: "bm1",
+					text: "Some text",
+					contentId: "book!ch01.xhtml",
+					volumeId: "book-volume",
+					dateCreated: new Date("2024-01-01"),
+				},
+			];
+
+			const result = await service.buildBookHighlightMap(bookmarks);
+			const chapters = result.get("The Starlight Archive")!;
+
+			expect(chapters).to.have.length(1);
+			expect(chapters[0].title).to.equal("Uncategorized");
+			expect(chapters[0].highlights).to.have.length(1);
+		});
+
+		it("handles multi-level hierarchy with ancestor emission", async function () {
+			const repo = {} as Repository;
+			repo.getBookTitleByContentId = () =>
+				Promise.resolve("The Starlight Archive");
+			repo.getTocEntriesByBookId = () =>
+				Promise.resolve([
+					{
+						title: "The Enchanted Forest",
+						contentId: "book!forest.html#id_1-1",
+						matchId: "book!forest.html#id_1",
+						depth: 1,
+						volumeIndex: 0,
+					},
+					{
+						title: "I. The Crystal Cave",
+						contentId: "book!forest.html#id_2-2",
+						matchId: "book!forest.html#id_2",
+						depth: 2,
+						volumeIndex: 1,
+					},
+					{
+						title: "1. The Hidden Door",
+						contentId: "book!forest.html#id_3-3",
+						matchId: "book!forest.html#id_3",
+						depth: 3,
+						volumeIndex: 2,
+					},
+					{
+						title: "II. The Mountain Pass",
+						contentId: "book!forest.html#id_4-2",
+						matchId: "book!forest.html#id_4",
+						depth: 2,
+						volumeIndex: 3,
+					},
+				]);
+
+			const service = new HighlightService(repo);
+			const bookmarks: Bookmark[] = [
+				{
+					bookmarkId: "bm1",
+					text: "Deep passage",
+					contentId: "book!forest.html#id_3",
+					volumeId: "book-volume",
+					dateCreated: new Date("2024-01-01"),
+				},
+			];
+
+			const result = await service.buildBookHighlightMap(bookmarks);
+			const chapters = result.get("The Starlight Archive")!;
+
+			// Should emit: Forest (depth 1), Crystal Cave (depth 2), Hidden Door (depth 3)
+			// Should NOT emit: Mountain Pass (no highlights)
+			expect(chapters).to.have.length(3);
+			expect(chapters[0].title).to.equal("The Enchanted Forest");
+			expect(chapters[0].depth).to.equal(1);
+			expect(chapters[1].title).to.equal("I. The Crystal Cave");
+			expect(chapters[1].depth).to.equal(2);
+			expect(chapters[2].title).to.equal("1. The Hidden Door");
+			expect(chapters[2].depth).to.equal(3);
+			expect(chapters[2].highlights).to.have.length(1);
 		});
 	});
 });

--- a/src/database/Highlight.ts
+++ b/src/database/Highlight.ts
@@ -1,5 +1,134 @@
-import { BookDetails, Bookmark, ChapterEntry } from "./interfaces";
+import { BookDetails, Bookmark, ChapterEntry, TocEntry } from "./interfaces";
 import { Repository } from "./repository";
+
+/**
+ * Groups bookmarks by their volumeId (book's ContentID).
+ * Bookmarks with empty/missing volumeId are grouped under an empty string key.
+ */
+export function groupBookmarksByVolume(
+	bookmarks: Bookmark[],
+): Map<string, Bookmark[]> {
+	const grouped = new Map<string, Bookmark[]>();
+	for (const bm of bookmarks) {
+		const key = bm.volumeId || "";
+		const arr = grouped.get(key) ?? [];
+		arr.push(bm);
+		grouped.set(key, arr);
+	}
+	return grouped;
+}
+
+/**
+ * Builds an index mapping TOC entry matchIds to their position in the TOC array.
+ * Only the first occurrence of each matchId is recorded.
+ */
+export function buildTocMatchIndex(toc: TocEntry[]): Map<string, number> {
+	const index = new Map<string, number>();
+	for (let i = 0; i < toc.length; i++) {
+		if (!index.has(toc[i].matchId)) {
+			index.set(toc[i].matchId, i);
+		}
+	}
+	return index;
+}
+
+/**
+ * Result of assigning bookmarks to TOC entries.
+ */
+export interface BookmarkAssignment {
+	/** Map of TOC index → bookmarks assigned to that entry */
+	assigned: Map<number, Bookmark[]>;
+	/** Bookmarks that couldn't be matched to any TOC entry */
+	uncategorized: Bookmark[];
+}
+
+/**
+ * Assigns bookmarks to TOC entries by matching bookmark contentId to TOC matchId.
+ * Unmatched bookmarks are collected in the uncategorized array.
+ */
+export function assignBookmarksToTocEntries(
+	bookmarks: Bookmark[],
+	matchIndex: Map<string, number>,
+): BookmarkAssignment {
+	const assigned = new Map<number, Bookmark[]>();
+	const uncategorized: Bookmark[] = [];
+
+	for (const bm of bookmarks) {
+		const idx = matchIndex.get(bm.contentId);
+		if (idx !== undefined) {
+			const arr = assigned.get(idx) ?? [];
+			arr.push(bm);
+			assigned.set(idx, arr);
+		} else {
+			uncategorized.push(bm);
+		}
+	}
+
+	return { assigned, uncategorized };
+}
+
+/**
+ * Finds all TOC indices that should be included in the output.
+ * This includes entries with highlights and their ancestor headings.
+ *
+ * Walks backwards from each highlighted entry to find parent headings
+ * (entries with lower depth values) that provide context.
+ */
+export function findRequiredHeadings(
+	toc: TocEntry[],
+	assignedIndices: Set<number>,
+): Set<number> {
+	const required = new Set<number>();
+
+	for (const i of assignedIndices) {
+		required.add(i);
+
+		// Walk backwards to find and mark ancestor headings
+		let needDepth = toc[i].depth;
+		for (let j = i - 1; j >= 0; j--) {
+			if (toc[j].depth < needDepth) {
+				required.add(j);
+				needDepth = toc[j].depth;
+				if (needDepth <= 1) break;
+			}
+		}
+	}
+
+	return required;
+}
+
+/**
+ * Builds the final ordered array of ChapterEntry objects from TOC entries.
+ * Only includes entries that are in the requiredIndices set and have a title.
+ * Appends uncategorized bookmarks as a final "Uncategorized" entry if any exist.
+ */
+export function buildChapterEntries(
+	toc: TocEntry[],
+	requiredIndices: Set<number>,
+	assigned: Map<number, Bookmark[]>,
+	uncategorized: Bookmark[],
+): ChapterEntry[] {
+	const chapters: ChapterEntry[] = [];
+
+	for (let i = 0; i < toc.length; i++) {
+		if (!requiredIndices.has(i) || !toc[i].title.trim()) continue;
+		chapters.push({
+			title: toc[i].title,
+			depth: toc[i].depth,
+			highlights: assigned.get(i) ?? [],
+		});
+	}
+
+	if (uncategorized.length > 0) {
+		chapters.push({
+			title: "Uncategorized",
+			depth: 1,
+			highlights: uncategorized,
+		});
+	}
+
+	return chapters;
+}
 
 export class HighlightService {
 	repo: Repository;
@@ -38,104 +167,74 @@ export class HighlightService {
 	 * Build a map of book title → ordered chapter entries with depth-based hierarchy.
 	 *
 	 * Uses ContentType=899 TOC entries ordered by VolumeIndex.
-	 * Matches bookmarks to TOC entries by stripping the trailing "-N" suffix.
+	 * Matches bookmarks to TOC entries by comparing bookmark contentId to TOC matchId.
 	 * Only emits TOC headings that have highlights or are ancestors of highlighted sections.
 	 */
 	async buildBookHighlightMap(
 		bookmarks: Bookmark[],
 	): Promise<Map<string, ChapterEntry[]>> {
 		const result = new Map<string, ChapterEntry[]>();
-
-		// Group bookmarks by volumeId (book's ContentID)
-		const bookmarksByBook = new Map<string, Bookmark[]>();
-		for (const bm of bookmarks) {
-			const key = bm.volumeId || "";
-			const arr = bookmarksByBook.get(key) ?? [];
-			arr.push(bm);
-			bookmarksByBook.set(key, arr);
-		}
+		const bookmarksByBook = groupBookmarksByVolume(bookmarks);
 
 		for (const [volumeId, bms] of bookmarksByBook) {
-			const bookTitle = volumeId
-				? ((await this.repo.getBookTitleByContentId(volumeId)) ??
-					this.unknownBookTitle)
-				: this.unknownBookTitle;
-
-			const toc = volumeId
-				? await this.repo.getTocEntriesByBookId(volumeId)
-				: [];
-
-			if (toc.length === 0) {
-				// No 899 entries: put all highlights under "Uncategorized"
-				result.set(bookTitle, [
-					{
-						title: "Uncategorized",
-						depth: 1,
-						highlights: bms,
-					},
-				]);
-				continue;
-			}
-
-			// Build matchId → TOC index map
-			const matchIndex = new Map<string, number>();
-			for (let i = 0; i < toc.length; i++) {
-				if (!matchIndex.has(toc[i].matchId)) {
-					matchIndex.set(toc[i].matchId, i);
-				}
-			}
-
-			// Assign highlights to TOC entries
-			const assigned = new Map<number, Bookmark[]>();
-			const uncategorized: Bookmark[] = [];
-			for (const bm of bms) {
-				const idx = matchIndex.get(bm.contentId);
-				if (idx !== undefined) {
-					const arr = assigned.get(idx) ?? [];
-					arr.push(bm);
-					assigned.set(idx, arr);
-				} else {
-					uncategorized.push(bm);
-				}
-			}
-
-			// Determine which headings are needed (ancestors of highlighted sections)
-			const headingNeeded = new Set<number>();
-			for (const i of assigned.keys()) {
-				headingNeeded.add(i);
-				// Walk backwards to find and mark ancestor headings
-				let needDepth = toc[i].depth;
-				for (let j = i - 1; j >= 0; j--) {
-					if (toc[j].depth < needDepth) {
-						headingNeeded.add(j);
-						needDepth = toc[j].depth;
-						if (needDepth <= 1) break;
-					}
-				}
-			}
-
-			// Build ordered ChapterEntry array
-			const chapters: ChapterEntry[] = [];
-			for (let i = 0; i < toc.length; i++) {
-				if (!headingNeeded.has(i) || !toc[i].title) continue;
-				chapters.push({
-					title: toc[i].title,
-					depth: toc[i].depth,
-					highlights: assigned.get(i) ?? [],
-				});
-			}
-
-			if (uncategorized.length > 0) {
-				chapters.push({
-					title: "Uncategorized",
-					depth: 1,
-					highlights: uncategorized,
-				});
-			}
-
+			const bookTitle = await this.resolveBookTitle(volumeId);
+			const chapters = await this.buildChaptersForBook(volumeId, bms);
 			result.set(bookTitle, chapters);
 		}
 
 		return result;
+	}
+
+	/**
+	 * Resolves a volumeId to a book title, falling back to unknownBookTitle.
+	 */
+	private async resolveBookTitle(volumeId: string): Promise<string> {
+		if (!volumeId) {
+			return this.unknownBookTitle;
+		}
+		return (
+			(await this.repo.getBookTitleByContentId(volumeId)) ??
+			this.unknownBookTitle
+		);
+	}
+
+	/**
+	 * Builds chapter entries for a single book's bookmarks.
+	 * If no TOC entries exist, returns all bookmarks under "Uncategorized".
+	 */
+	private async buildChaptersForBook(
+		volumeId: string,
+		bookmarks: Bookmark[],
+	): Promise<ChapterEntry[]> {
+		const toc = volumeId
+			? await this.repo.getTocEntriesByBookId(volumeId)
+			: [];
+
+		if (toc.length === 0) {
+			return [
+				{
+					title: "Uncategorized",
+					depth: 1,
+					highlights: bookmarks,
+				},
+			];
+		}
+
+		const matchIndex = buildTocMatchIndex(toc);
+		const { assigned, uncategorized } = assignBookmarksToTocEntries(
+			bookmarks,
+			matchIndex,
+		);
+		const requiredHeadings = findRequiredHeadings(
+			toc,
+			new Set(assigned.keys()),
+		);
+
+		return buildChapterEntries(
+			toc,
+			requiredHeadings,
+			assigned,
+			uncategorized,
+		);
 	}
 }

--- a/src/database/Highlight.ts
+++ b/src/database/Highlight.ts
@@ -1,8 +1,5 @@
-import { BookDetails, Bookmark, Content, Highlight } from "./interfaces";
+import { BookDetails, Bookmark, ChapterEntry } from "./interfaces";
 import { Repository } from "./repository";
-
-type bookTitle = string;
-export type chapter = string;
 
 export class HighlightService {
 	repo: Repository;
@@ -26,138 +23,6 @@ export class HighlightService {
 		return details;
 	}
 
-	convertToMap(arr: Highlight[]): Map<bookTitle, Map<chapter, Bookmark[]>> {
-		const m = new Map<string, Map<string, Bookmark[]>>();
-
-		arr.forEach((x) => {
-			if (!x.content.bookTitle) {
-				throw new Error("bookTitle must be set");
-			}
-
-			const existingBook = m.get(x.content.bookTitle);
-			if (existingBook) {
-				const existingChapter = existingBook.get(x.content.title);
-
-				if (existingChapter) {
-					existingChapter.push(x.bookmark);
-				} else {
-					existingBook.set(x.content.title, [x.bookmark]);
-				}
-			} else {
-				m.set(
-					x.content.bookTitle,
-					new Map<string, Bookmark[]>().set(x.content.title, [
-						x.bookmark,
-					]),
-				);
-			}
-		});
-
-		return m;
-	}
-
-	async getAllHighlight(
-		sortByChapterProgress?: boolean,
-	): Promise<Highlight[]> {
-		const highlights: Highlight[] = [];
-
-		const bookmarks = await this.repo.getAllBookmark(sortByChapterProgress);
-		for (const bookmark of bookmarks) {
-			highlights.push(await this.createHighlightFromBookmark(bookmark));
-		}
-
-		return highlights.sort(function (a, b): number {
-			if (!a.content.bookTitle || !b.content.bookTitle) {
-				throw new Error("bookTitle must be set");
-			}
-
-			return (
-				a.content.bookTitle.localeCompare(b.content.bookTitle) ||
-				a.content.contentId.localeCompare(b.content.contentId)
-			);
-		});
-	}
-
-	async createHighlightFromBookmark(bookmark: Bookmark): Promise<Highlight> {
-		let content = await this.repo.getContentByContentId(bookmark.contentId);
-
-		if (content == null) {
-			content = await this.repo.getContentLikeContentId(
-				bookmark.contentId,
-			);
-			if (content == null) {
-				console.warn(
-					`bookmark seems to link to a non existing content: ${bookmark.contentId}`,
-				);
-				return {
-					bookmark: bookmark,
-					content: {
-						title: this.unknownBookTitle,
-						contentId: bookmark.contentId,
-						chapterIdBookmarked: "false",
-						bookTitle: this.unknownBookTitle,
-					},
-				};
-			}
-		}
-
-		if (content.chapterIdBookmarked == null) {
-			return {
-				bookmark: bookmark,
-				content: await this.findRightContentForBookmark(
-					bookmark,
-					content,
-				),
-			};
-		}
-
-		return {
-			bookmark: bookmark,
-			content: content,
-		};
-	}
-
-	private async findRightContentForBookmark(
-		bookmark: Bookmark,
-		originalContent: Content,
-	): Promise<Content> {
-		if (!originalContent.bookTitle) {
-			throw new Error("bookTitle field must be set");
-		}
-
-		const contents =
-			await this.repo.getAllContentByBookTitleOrderedByContentId(
-				originalContent.bookTitle,
-			);
-		const potential =
-			await this.repo.getFirstContentLikeContentIdWithBookmarkIdNotNull(
-				originalContent.contentId,
-			);
-		if (potential) {
-			return potential;
-		}
-
-		let foundContent: Content | null = null;
-
-		for (const c of contents) {
-			if (c.chapterIdBookmarked) {
-				foundContent = c;
-			}
-
-			if (c.contentId === bookmark.contentId && foundContent) {
-				return foundContent;
-			}
-		}
-
-		if (foundContent) {
-			console.warn(
-				`was not able to find chapterIdBookmarked for book ${originalContent.bookTitle}`,
-			);
-		}
-
-		return originalContent;
-	}
-
 	async getAllBooks(): Promise<Map<string, BookDetails>> {
 		const books = await this.repo.getAllBookDetails();
 		const bookMap = new Map<string, BookDetails>();
@@ -169,12 +34,108 @@ export class HighlightService {
 		return bookMap;
 	}
 
-	async getAllContentByBookTitle(bookTitle: string): Promise<Content[]> {
-		return this.repo.getAllContentByBookTitle(bookTitle);
-	}
+	/**
+	 * Build a map of book title → ordered chapter entries with depth-based hierarchy.
+	 *
+	 * Uses ContentType=899 TOC entries ordered by VolumeIndex.
+	 * Matches bookmarks to TOC entries by stripping the trailing "-N" suffix.
+	 * Only emits TOC headings that have highlights or are ancestors of highlighted sections.
+	 */
+	async buildBookHighlightMap(
+		bookmarks: Bookmark[],
+	): Promise<Map<string, ChapterEntry[]>> {
+		const result = new Map<string, ChapterEntry[]>();
 
-	// Create an empty content map for books without highlights
-	createEmptyContentMap(): Map<chapter, Bookmark[]> {
-		return new Map<chapter, Bookmark[]>();
+		// Group bookmarks by volumeId (book's ContentID)
+		const bookmarksByBook = new Map<string, Bookmark[]>();
+		for (const bm of bookmarks) {
+			const key = bm.volumeId || "";
+			const arr = bookmarksByBook.get(key) ?? [];
+			arr.push(bm);
+			bookmarksByBook.set(key, arr);
+		}
+
+		for (const [volumeId, bms] of bookmarksByBook) {
+			const bookTitle = volumeId
+				? ((await this.repo.getBookTitleByContentId(volumeId)) ??
+					this.unknownBookTitle)
+				: this.unknownBookTitle;
+
+			const toc = volumeId
+				? await this.repo.getTocEntriesByBookId(volumeId)
+				: [];
+
+			if (toc.length === 0) {
+				// No 899 entries: put all highlights under "Uncategorized"
+				result.set(bookTitle, [
+					{
+						title: "Uncategorized",
+						depth: 1,
+						highlights: bms,
+					},
+				]);
+				continue;
+			}
+
+			// Build matchId → TOC index map
+			const matchIndex = new Map<string, number>();
+			for (let i = 0; i < toc.length; i++) {
+				if (!matchIndex.has(toc[i].matchId)) {
+					matchIndex.set(toc[i].matchId, i);
+				}
+			}
+
+			// Assign highlights to TOC entries
+			const assigned = new Map<number, Bookmark[]>();
+			const uncategorized: Bookmark[] = [];
+			for (const bm of bms) {
+				const idx = matchIndex.get(bm.contentId);
+				if (idx !== undefined) {
+					const arr = assigned.get(idx) ?? [];
+					arr.push(bm);
+					assigned.set(idx, arr);
+				} else {
+					uncategorized.push(bm);
+				}
+			}
+
+			// Determine which headings are needed (ancestors of highlighted sections)
+			const headingNeeded = new Set<number>();
+			for (const i of assigned.keys()) {
+				headingNeeded.add(i);
+				// Walk backwards to find and mark ancestor headings
+				let needDepth = toc[i].depth;
+				for (let j = i - 1; j >= 0; j--) {
+					if (toc[j].depth < needDepth) {
+						headingNeeded.add(j);
+						needDepth = toc[j].depth;
+						if (needDepth <= 1) break;
+					}
+				}
+			}
+
+			// Build ordered ChapterEntry array
+			const chapters: ChapterEntry[] = [];
+			for (let i = 0; i < toc.length; i++) {
+				if (!headingNeeded.has(i) || !toc[i].title) continue;
+				chapters.push({
+					title: toc[i].title,
+					depth: toc[i].depth,
+					highlights: assigned.get(i) ?? [],
+				});
+			}
+
+			if (uncategorized.length > 0) {
+				chapters.push({
+					title: "Uncategorized",
+					depth: 1,
+					highlights: uncategorized,
+				});
+			}
+
+			result.set(bookTitle, chapters);
+		}
+
+		return result;
 	}
 }

--- a/src/database/interfaces.ts
+++ b/src/database/interfaces.ts
@@ -3,8 +3,27 @@ export interface Bookmark {
 	bookmarkId: string;
 	text: string;
 	contentId: string;
+	volumeId: string;
 	note?: string;
 	dateCreated: Date;
+}
+
+export interface TocEntry {
+	title: string;
+	/** ContentID with trailing "-N" stripped, used for matching bookmarks */
+	matchId: string;
+	/** Original ContentID from the 899 row */
+	contentId: string;
+	/** Depth level extracted from trailing "-N" suffix (1=top, 2=part, 3=section...) */
+	depth: number;
+	/** VolumeIndex from DB, preserves TOC ordering */
+	volumeIndex: number;
+}
+
+export interface ChapterEntry {
+	title: string;
+	depth: number;
+	highlights: Bookmark[];
 }
 
 export interface Content {
@@ -12,11 +31,6 @@ export interface Content {
 	contentId: string;
 	chapterIdBookmarked?: string;
 	bookTitle?: string;
-}
-
-export interface Highlight {
-	bookmark: Bookmark;
-	content: Content;
 }
 
 export interface BookDetails {

--- a/src/database/repository.ts
+++ b/src/database/repository.ts
@@ -325,9 +325,7 @@ export class Repository {
 		return entries;
 	}
 
-	async getBookTitleByContentId(
-		contentId: string,
-	): Promise<string | null> {
+	async getBookTitleByContentId(contentId: string): Promise<string | null> {
 		const statement = this.db.prepare(
 			`SELECT Title FROM content WHERE ContentID = $id AND BookID IS NULL LIMIT 1`,
 			{ $id: contentId },

--- a/src/database/repository.ts
+++ b/src/database/repository.ts
@@ -1,5 +1,36 @@
 import { Database, Statement } from "sql.js";
-import { BookDetails, Bookmark, Content } from "./interfaces";
+import { BookDetails, Bookmark, Content, TocEntry } from "./interfaces";
+
+/**
+ * Strip the trailing "-N" (digits) suffix from a ContentID.
+ * E.g. "...xhtml#chapter01_4-2" → "...xhtml#chapter01_4"
+ *      "...Cover.xhtml-1"       → "...Cover.xhtml"
+ */
+function stripSuffix(contentId: string): string {
+	const pos = contentId.lastIndexOf("-");
+	if (pos === -1) return contentId;
+	const after = contentId.substring(pos + 1);
+	if (after.length > 0 && /^\d+$/.test(after)) {
+		return contentId.substring(0, pos);
+	}
+	return contentId;
+}
+
+/**
+ * Extract depth level from trailing "-N" suffix. Returns 1 if no suffix found.
+ * E.g. "...xhtml#chapter01_4-2" → 2, "...Cover.xhtml-1" → 1
+ */
+function extractDepth(contentId: string): number {
+	const pos = contentId.lastIndexOf("-");
+	if (pos === -1) return 1;
+	const after = contentId.substring(pos + 1);
+	if (after.length > 0 && /^\d+$/.test(after)) {
+		return parseInt(after, 10) || 1;
+	}
+	return 1;
+}
+
+export { stripSuffix, extractDepth };
 
 export class Repository {
 	db: Database;
@@ -12,11 +43,11 @@ export class Repository {
 		let res;
 		if (sortByChapterProgress) {
 			res = this.db.exec(
-				`select BookmarkID, Text, ContentID, annotation, DateCreated, ChapterProgress from Bookmark where Text is not null order by ChapterProgress ASC, DateCreated ASC;`,
+				`select BookmarkID, Text, ContentID, annotation, DateCreated, ChapterProgress, VolumeID from Bookmark where Text is not null order by ChapterProgress ASC, DateCreated ASC;`,
 			);
 		} else {
 			res = this.db.exec(
-				`select BookmarkID, Text, ContentID, annotation, DateCreated, ChapterProgress from Bookmark where Text is not null order by DateCreated ASC;`,
+				`select BookmarkID, Text, ContentID, annotation, DateCreated, ChapterProgress, VolumeID from Bookmark where Text is not null order by DateCreated ASC;`,
 			);
 		}
 		const bookmarks: Bookmark[] = [];
@@ -49,6 +80,7 @@ export class Repository {
 				contentId: row[2].toString(),
 				note: row[3]?.toString(),
 				dateCreated: new Date(row[4].toString()),
+				volumeId: row[6]?.toString() ?? "",
 			});
 		});
 
@@ -65,7 +97,7 @@ export class Repository {
 
 	async getBookmarkById(id: string): Promise<Bookmark | null> {
 		const statement = this.db.prepare(
-			`select BookmarkID, Text, ContentID, annotation, DateCreated from Bookmark where BookmarkID = $id;`,
+			`select BookmarkID, Text, ContentID, annotation, DateCreated, VolumeID from Bookmark where BookmarkID = $id;`,
 			{
 				$id: id,
 			},
@@ -87,6 +119,7 @@ export class Repository {
 			contentId: row[2].toString(),
 			note: row[3]?.toString(),
 			dateCreated: new Date(row[4].toString()),
+			volumeId: row[5]?.toString() ?? "",
 		};
 	}
 
@@ -264,6 +297,49 @@ export class Repository {
 
 		statement.free();
 		return books;
+	}
+
+	async getTocEntriesByBookId(bookContentId: string): Promise<TocEntry[]> {
+		const statement = this.db.prepare(
+			`SELECT ContentID, Title, VolumeIndex
+			 FROM content
+			 WHERE BookID = $bookId
+			   AND ContentType = 899
+			 ORDER BY VolumeIndex`,
+			{ $bookId: bookContentId },
+		);
+
+		const entries: TocEntry[] = [];
+		while (statement.step()) {
+			const row = statement.get();
+			const contentId = row[0]?.toString() ?? "";
+			entries.push({
+				title: row[1]?.toString() ?? "",
+				contentId: contentId,
+				matchId: stripSuffix(contentId),
+				depth: extractDepth(contentId),
+				volumeIndex: row[2] ? +row[2].toString() : 0,
+			});
+		}
+		statement.free();
+		return entries;
+	}
+
+	async getBookTitleByContentId(
+		contentId: string,
+	): Promise<string | null> {
+		const statement = this.db.prepare(
+			`SELECT Title FROM content WHERE ContentID = $id AND BookID IS NULL LIMIT 1`,
+			{ $id: contentId },
+		);
+
+		if (!statement.step()) {
+			statement.free();
+			return null;
+		}
+		const row = statement.get();
+		statement.free();
+		return row[0]?.toString() ?? null;
 	}
 
 	private parseContentStatement(statement: Statement): Content[] {

--- a/src/template/template.test.ts
+++ b/src/template/template.test.ts
@@ -1,36 +1,38 @@
 import * as chai from "chai";
 import { applyTemplateTransformations, defaultTemplate } from "./template";
-import { chapter } from "../database/Highlight";
-import { Bookmark } from "../database/interfaces";
+import { ChapterEntry } from "../database/interfaces";
 
 describe("template", async function () {
 	const testDate = new Date("2023-01-01T12:00:00Z");
-	const chapters = new Map<chapter, Bookmark[]>([
-		[
-			"Chapter 1",
-			[
+	const chapters: ChapterEntry[] = [
+		{
+			title: "Chapter 1",
+			depth: 1,
+			highlights: [
 				{
 					bookmarkId: "1",
 					text: "test",
 					contentId: "content1",
+					volumeId: "book1",
 					dateCreated: testDate,
 				},
 			],
-		],
-
-		[
-			"Chapter 2",
-			[
+		},
+		{
+			title: "Chapter 2",
+			depth: 1,
+			highlights: [
 				{
 					bookmarkId: "1",
 					text: "test2",
 					contentId: "content2",
+					volumeId: "book1",
 					dateCreated: testDate,
 					note: "note2",
 				},
 			],
-		],
-	]);
+		},
+	];
 
 	function normalize(s: string) {
 		return s
@@ -141,8 +143,8 @@ title: <%= it.bookDetails.title %>
 ---
 # <%= it.bookDetails.title %>
 
-<% it.chapters.forEach(([chapterName, highlights]) => { %>
-<%- highlights.forEach(h => { -%>
+<% it.chapters.forEach((chapter) => { %>
+<%- chapter.highlights.forEach(h => { -%>
 <%= h.text %>
 <% }) %>
 <% }) %>`,
@@ -168,10 +170,10 @@ title: "<%= it.bookDetails.title %>"
 
 # <%= it.bookDetails.title %>
 
-<% it.chapters.forEach(([chapterName, highlights]) => { -%>
-## <%= chapterName %>
+<% it.chapters.forEach((chapter) => { -%>
+<%= '#'.repeat(chapter.depth + 1) %> <%= chapter.title %>
 
-<% highlights.forEach(h => { -%>
+<% chapter.highlights.forEach(h => { -%>
 <%= h.text %>
 
 *Created: <%= h.dateCreated.getFullYear() %>-<%= String(h.dateCreated.getMonth() + 1).padStart(2, '0') %>-<%= String(h.dateCreated.getDate()).padStart(2, '0') %>*

--- a/src/template/template.ts
+++ b/src/template/template.ts
@@ -1,6 +1,9 @@
 import { Eta } from "eta";
-import { BookDetails, ReadStatus, Bookmark } from "../database/interfaces";
-import { chapter } from "../database/Highlight";
+import {
+	BookDetails,
+	ChapterEntry,
+	ReadStatus,
+} from "../database/interfaces";
 
 const eta = new Eta({ autoEscape: false, autoTrim: false });
 
@@ -26,10 +29,10 @@ timeSpentReading: <%= it.bookDetails.timeSpentReading ?? '' %>
 
 ## Highlights
 
-<% it.chapters.forEach(([chapterName, highlights]) => { -%>
-## <%= chapterName.trim() %>
+<% it.chapters.forEach((chapter) => { -%>
+<%= '#'.repeat(chapter.depth + 1) %> <%= chapter.title.trim() %>
 
-<% highlights.forEach((highlight) => { -%>
+<% chapter.highlights.forEach((highlight) => { -%>
 <%= highlight.text %>
 
 <% if (highlight.note) { -%>
@@ -46,13 +49,12 @@ timeSpentReading: <%= it.bookDetails.timeSpentReading ?? '' %>
 
 export function applyTemplateTransformations(
 	rawTemplate: string,
-	chapters: Map<chapter, Bookmark[]>,
+	chapters: ChapterEntry[],
 	bookDetails: BookDetails,
 ): string {
-	const chaptersArr = Array.from(chapters.entries());
 	const rendered = eta.renderString(rawTemplate, {
 		bookDetails,
-		chapters: chaptersArr,
+		chapters,
 		ReadStatus,
 	});
 

--- a/src/template/template.ts
+++ b/src/template/template.ts
@@ -1,9 +1,5 @@
 import { Eta } from "eta";
-import {
-	BookDetails,
-	ChapterEntry,
-	ReadStatus,
-} from "../database/interfaces";
+import { BookDetails, ChapterEntry, ReadStatus } from "../database/interfaces";
 
 const eta = new Eta({ autoEscape: false, autoTrim: false });
 


### PR DESCRIPTION
## Summary
- Replace the flat `Map<chapter, Bookmark[]>` highlight grouping with a depth-aware `ChapterEntry[]` structure that uses Kobo's ContentType=899 TOC entries to determine chapter hierarchy and ordering
- Add `volumeId` to `Bookmark` and new repository methods (`getTocEntriesByBookId`, `getBookTitleByContentId`) to query TOC structure from the Kobo database
- Update the default template to render depth-based markdown headings (`###`, `####`, etc.) instead of a fixed `##` for all chapters
- Remove dead code: `convertToMap`, `getAllHighlight`, `createHighlightFromBookmark`, `createEmptyContentMap`, the `Highlight` interface, and their associated tests

## Breaking changes
Custom templates using `it.chapters.forEach(([chapterName, highlights]) => { ... })` must be updated to `it.chapters.forEach((chapter) => { ... })` and access `chapter.title`, `chapter.depth`, and `chapter.highlights`.

## Test plan
- [ ] Unit tests for `stripSuffix` and `extractDepth` cover suffix stripping and depth extraction
- [ ] Unit tests for `buildBookHighlightMap` cover TOC matching, ancestor heading emission, uncategorized fallback, and multi-level hierarchy
- [ ] Template tests updated to use the new `ChapterEntry[]` data structure
- [ ] Verify with a real Kobo database that highlights are grouped under correct chapter headings