### PR TITLE
Single-book append, path persistence, chapter sort improvements

### DIFF
--- a/src/database/Highlight.ts
+++ b/src/database/Highlight.ts
@@ -109,6 +109,24 @@ export class HighlightService {
 			);
 		}
 
+		// Calculate reliable book-level progress using the sorted content list.
+		// Kobo's ChapterProgress is progress within a single EPUB spine item,
+		// which is 0→1 per chapter for multi-spine EPUBs but 0→1 for the whole
+		// book for single-spine EPUBs. bookProgress normalises across both cases.
+		const totalChapters = allContents.length;
+		if (totalChapters > 0) {
+			for (const h of highlights) {
+				const idx = allContents.findIndex(
+					(c) => c.contentId === h.content.contentId,
+				);
+				if (idx !== -1) {
+					h.bookmark.bookProgress =
+						(idx + (h.bookmark.chapterProgress ?? 0)) /
+						totalChapters;
+				}
+			}
+		}
+
 		return highlights;
 	}
 
@@ -206,7 +224,7 @@ export class HighlightService {
 			highlights.push(await this.createHighlightFromBookmark(bookmark));
 		}
 
-		return highlights.sort((a, b) => {
+		const sorted = highlights.sort((a, b) => {
 			if (!a.content.bookTitle || !b.content.bookTitle) {
 				throw new Error("bookTitle must be set");
 			}
@@ -220,6 +238,32 @@ export class HighlightService {
 				? a.content.contentId.localeCompare(b.content.contentId)
 				: 0;
 		});
+
+		// Calculate bookProgress for every highlight. Cache per-book content
+		// queries so we only hit the DB once per unique book title.
+		const contentsByBook = new Map<string, Content[]>();
+		for (const h of sorted) {
+			if (!h.content.bookTitle) continue;
+			let contents = contentsByBook.get(h.content.bookTitle);
+			if (!contents) {
+				contents =
+					await this.repo.getAllContentByBookTitleOrderedByContentId(
+						h.content.bookTitle,
+					);
+				contentsByBook.set(h.content.bookTitle, contents);
+			}
+			const totalChapters = contents.length;
+			if (totalChapters === 0) continue;
+			const idx = contents.findIndex(
+				(c) => c.contentId === h.content.contentId,
+			);
+			if (idx !== -1) {
+				h.bookmark.bookProgress =
+					(idx + (h.bookmark.chapterProgress ?? 0)) / totalChapters;
+			}
+		}
+
+		return sorted;
 	}
 
 	async createHighlightFromBookmark(bookmark: Bookmark): Promise<Highlight> {

--- a/src/database/Highlight.ts
+++ b/src/database/Highlight.ts
@@ -109,16 +109,6 @@ export class HighlightService {
 			);
 		}
 
-		// Calculate word-count-weighted book progress. Falls back to uniform
-		// chapter weighting when WordCount data is unavailable.
-		for (const h of highlights) {
-			h.bookmark.bookProgress = this.calcBookProgress(
-				h.content.contentId,
-				h.bookmark.chapterProgress,
-				allContents,
-			);
-		}
-
 		return highlights;
 	}
 
@@ -231,26 +221,6 @@ export class HighlightService {
 				: 0;
 		});
 
-		// Calculate word-count-weighted book progress for every highlight.
-		// Cache per-book content queries so we only hit the DB once per book.
-		const contentsByBook = new Map<string, Content[]>();
-		for (const h of sorted) {
-			if (!h.content.bookTitle) continue;
-			let contents = contentsByBook.get(h.content.bookTitle);
-			if (!contents) {
-				contents =
-					await this.repo.getAllContentByBookTitleOrderedByContentId(
-						h.content.bookTitle,
-					);
-				contentsByBook.set(h.content.bookTitle, contents);
-			}
-			h.bookmark.bookProgress = this.calcBookProgress(
-				h.content.contentId,
-				h.bookmark.chapterProgress,
-				contents,
-			);
-		}
-
 		return sorted;
 	}
 
@@ -332,56 +302,6 @@ export class HighlightService {
 		}
 
 		return originalContent;
-	}
-
-	// Calculates book-level progress (0–1) for a highlight given the ordered
-	// list of all content rows for its book.
-	//
-	// Strategy:
-	//   1. Word-count weighted — if WordCount is populated for at least one
-	//      chapter, use cumulative word counts as the numerator and total word
-	//      count as the denominator. Long chapters contribute proportionally
-	//      more than short ones.
-	//   2. Uniform fallback — when WordCount is absent (all NULL/0), fall back
-	//      to (chapterIndex + chapterProgress) / totalChapters.
-	//
-	// IMPORTANT: we restrict to rows where chapterIdBookmarked != null (actual
-	// chapter/spine entries). Kobo's content table also contains a top-level
-	// book row (ContentType 6) that often stores the *total* book word count in
-	// WordCount. Including it would double-count every word and shift all
-	// percentages into the upper half of the 0–1 range.
-	private calcBookProgress(
-		contentId: string,
-		chapterProgress: number | undefined,
-		allContents: Content[],
-	): number | undefined {
-		// Only consider actual chapter entries.
-		const chapters = allContents.filter(
-			(c) => c.chapterIdBookmarked != null,
-		);
-
-		const idx = chapters.findIndex((c) => c.contentId === contentId);
-		if (idx === -1) return undefined;
-
-		const cp = chapterProgress ?? 0;
-		const totalWords = chapters.reduce(
-			(sum, c) => sum + (c.wordCount ?? 0),
-			0,
-		);
-
-		if (totalWords > 0) {
-			// Word-count weighted path.
-			const wordsBeforeChapter = chapters
-				.slice(0, idx)
-				.reduce((sum, c) => sum + (c.wordCount ?? 0), 0);
-			const currentChapterWords = chapters[idx].wordCount ?? 0;
-			return (wordsBeforeChapter + cp * currentChapterWords) / totalWords;
-		} else {
-			// Uniform fallback path.
-			const total = chapters.length;
-			if (total === 0) return undefined;
-			return (idx + cp) / total;
-		}
 	}
 
 	async getAllBooks(): Promise<Map<string, BookDetails>> {

--- a/src/database/Highlight.ts
+++ b/src/database/Highlight.ts
@@ -60,12 +60,128 @@ export class HighlightService {
 		return m;
 	}
 
+	// Efficiently fetches highlights for a single book.
+	//
+	// The naive approach (getAllHighlight + filter) fetches every bookmark in the
+	// database and issues 1-4 DB queries per bookmark to resolve its content,
+	// then discards all results except the target book. For a device with many
+	// books this is extremely wasteful.
+	//
+	// Instead we:
+	//   1. Fetch only this book's bookmarks via a filtered SQL query (1 DB call).
+	//   2. Fetch all content entries for the book ordered by ContentID (1 DB call).
+	//   3. Resolve content associations entirely in-memory — O(M) per bookmark
+	//      where M is the number of chapters, rather than issuing further DB calls.
 	async getHighlightsByBookTitle(
 		bookTitle: string,
 		sortByChapterProgress?: boolean,
 	): Promise<Highlight[]> {
-		const all = await this.getAllHighlight(sortByChapterProgress);
-		return all.filter((h) => h.content.bookTitle === bookTitle);
+		const [bookmarks, allContents] = await Promise.all([
+			this.repo.getBookmarksByBookTitle(bookTitle, sortByChapterProgress),
+			this.repo.getAllContentByBookTitleOrderedByContentId(bookTitle),
+		]);
+
+		// Build an exact-match index for O(1) lookups.
+		const contentById = new Map<string, Content>(
+			allContents.map((c) => [c.contentId, c]),
+		);
+
+		const highlights: Highlight[] = [];
+		for (const bookmark of bookmarks) {
+			highlights.push(
+				this.resolveHighlightInMemory(
+					bookmark,
+					bookTitle,
+					contentById,
+					allContents,
+				),
+			);
+		}
+
+		return highlights;
+	}
+
+	// In-memory equivalent of createHighlightFromBookmark + findRightContentForBookmark,
+	// using pre-fetched content data to avoid per-bookmark DB queries.
+	private resolveHighlightInMemory(
+		bookmark: Bookmark,
+		bookTitle: string,
+		contentById: Map<string, Content>,
+		allContents: Content[], // ordered by ContentID
+	): Highlight {
+		// 1. Exact match.
+		let content = contentById.get(bookmark.contentId) ?? null;
+
+		// 2. Fuzzy match: find a content entry whose ContentID contains the bookmark's ContentID.
+		if (!content) {
+			content =
+				allContents.find((c) =>
+					c.contentId.includes(bookmark.contentId),
+				) ?? null;
+		}
+
+		if (!content) {
+			console.warn(
+				`bookmark seems to link to a non existing content: ${bookmark.contentId}`,
+			);
+			return {
+				bookmark,
+				content: {
+					title: this.unknownBookTitle,
+					contentId: bookmark.contentId,
+					chapterIdBookmarked: "false",
+					bookTitle: this.unknownBookTitle,
+				},
+			};
+		}
+
+		// 3. If chapterIdBookmarked is null, walk the sorted content list to find
+		//    the right chapter — mirrors findRightContentForBookmark logic.
+		if (content.chapterIdBookmarked == null) {
+			content = this.findRightContentInMemory(
+				bookmark,
+				content,
+				allContents,
+			);
+		}
+
+		return { bookmark, content };
+	}
+
+	// In-memory equivalent of findRightContentForBookmark.
+	private findRightContentInMemory(
+		bookmark: Bookmark,
+		originalContent: Content,
+		allContents: Content[], // ordered by ContentID
+	): Content {
+		// Mirror getFirstContentLikeContentIdWithBookmarkIdNotNull:
+		// find a content whose ContentID starts with originalContent's ContentID
+		// and has chapterIdBookmarked set.
+		const potential = allContents.find(
+			(c) =>
+				c.contentId.startsWith(originalContent.contentId) &&
+				c.chapterIdBookmarked != null,
+		);
+		if (potential) return potential;
+
+		// Fall back to sequential scan (mirrors the for-loop in findRightContentForBookmark).
+		let foundContent: Content | null = null;
+		for (const c of allContents) {
+			if (c.chapterIdBookmarked) {
+				foundContent = c;
+			}
+			if (c.contentId === bookmark.contentId && foundContent) {
+				return foundContent;
+			}
+		}
+
+		if (foundContent) {
+			console.warn(
+				`was not able to find chapterIdBookmarked for book ${originalContent.bookTitle}`,
+			);
+		}
+
+		return originalContent;
 	}
 
 	async getAllHighlight(

--- a/src/database/Highlight.ts
+++ b/src/database/Highlight.ts
@@ -13,6 +13,10 @@ export class HighlightService {
 		this.repo = repo;
 	}
 
+	async getBookDetailsByIsbn(isbn: string): Promise<BookDetails | null> {
+		return this.repo.getBookDetailsByIsbn(isbn);
+	}
+
 	async getBookDetailsFromBookTitle(title: string): Promise<BookDetails> {
 		const details = await this.repo.getBookDetailsByBookTitle(title);
 
@@ -54,6 +58,14 @@ export class HighlightService {
 		});
 
 		return m;
+	}
+
+	async getHighlightsByBookTitle(
+		bookTitle: string,
+		sortByChapterProgress?: boolean,
+	): Promise<Highlight[]> {
+		const all = await this.getAllHighlight(sortByChapterProgress);
+		return all.filter((h) => h.content.bookTitle === bookTitle);
 	}
 
 	async getAllHighlight(

--- a/src/database/Highlight.ts
+++ b/src/database/Highlight.ts
@@ -99,14 +99,19 @@ export class HighlightService {
 			);
 		}
 
-		// If sortByChapterOrder is enabled, sort by contentId so chapters appear
-		// in book order. Highlights within the same chapter keep their relative
-		// SQL-determined order (stable sort), so sortByChapterProgress still
-		// controls within-chapter ordering independently.
+		// If sortByChapterOrder is enabled, sort by VolumeIndex (the explicit
+		// EPUB spine index Kobo stores in the content table). This is immune to
+		// ContentID string-ordering quirks on books with non-sequential filenames.
+		// Fall back to ContentID comparison when VolumeIndex is absent.
+		// Highlights within the same chapter keep their SQL-determined order.
 		if (sortByChapterOrder) {
-			highlights.sort((a, b) =>
-				a.content.contentId.localeCompare(b.content.contentId),
-			);
+			highlights.sort((a, b) => {
+				const aVol = a.content.volumeIndex;
+				const bVol = b.content.volumeIndex;
+				if (aVol != null && bVol != null && aVol !== bVol)
+					return aVol - bVol;
+				return a.content.contentId.localeCompare(b.content.contentId);
+			});
 		}
 
 		return highlights;
@@ -216,9 +221,14 @@ export class HighlightService {
 			);
 			if (bookCmp !== 0) return bookCmp;
 
-			return sortByChapterOrder
-				? a.content.contentId.localeCompare(b.content.contentId)
-				: 0;
+			if (sortByChapterOrder) {
+				const aVol = a.content.volumeIndex;
+				const bVol = b.content.volumeIndex;
+				if (aVol != null && bVol != null && aVol !== bVol)
+					return aVol - bVol;
+				return a.content.contentId.localeCompare(b.content.contentId);
+			}
+			return 0;
 		});
 
 		return sorted;

--- a/src/database/Highlight.ts
+++ b/src/database/Highlight.ts
@@ -75,6 +75,7 @@ export class HighlightService {
 	async getHighlightsByBookTitle(
 		bookTitle: string,
 		sortByChapterProgress?: boolean,
+		sortByChapterOrder?: boolean,
 	): Promise<Highlight[]> {
 		const [bookmarks, allContents] = await Promise.all([
 			this.repo.getBookmarksByBookTitle(bookTitle, sortByChapterProgress),
@@ -98,13 +99,17 @@ export class HighlightService {
 			);
 		}
 
-		// Sort by contentId so chapters appear in book order regardless of the
-		// SQL sort used to fetch bookmarks. Highlights within the same chapter
-		// keep their relative order (stable sort) from the SQL query, so
-		// sortByChapterProgress still governs within-chapter ordering.
-		return highlights.sort((a, b) =>
-			a.content.contentId.localeCompare(b.content.contentId),
-		);
+		// If sortByChapterOrder is enabled, sort by contentId so chapters appear
+		// in book order. Highlights within the same chapter keep their relative
+		// SQL-determined order (stable sort), so sortByChapterProgress still
+		// controls within-chapter ordering independently.
+		if (sortByChapterOrder) {
+			highlights.sort((a, b) =>
+				a.content.contentId.localeCompare(b.content.contentId),
+			);
+		}
+
+		return highlights;
 	}
 
 	// In-memory equivalent of createHighlightFromBookmark + findRightContentForBookmark,

--- a/src/database/Highlight.ts
+++ b/src/database/Highlight.ts
@@ -98,7 +98,13 @@ export class HighlightService {
 			);
 		}
 
-		return highlights;
+		// Sort by contentId so chapters appear in book order regardless of the
+		// SQL sort used to fetch bookmarks. Highlights within the same chapter
+		// keep their relative order (stable sort) from the SQL query, so
+		// sortByChapterProgress still governs within-chapter ordering.
+		return highlights.sort((a, b) =>
+			a.content.contentId.localeCompare(b.content.contentId),
+		);
 	}
 
 	// In-memory equivalent of createHighlightFromBookmark + findRightContentForBookmark,

--- a/src/database/Highlight.ts
+++ b/src/database/Highlight.ts
@@ -1,4 +1,4 @@
-import { BookDetails, Bookmark, Content, Highlight, HighlightSort } from "./interfaces";
+import { BookDetails, Bookmark, Content, Highlight } from "./interfaces";
 import { Repository } from "./repository";
 
 type bookTitle = string;
@@ -74,10 +74,11 @@ export class HighlightService {
 	//      where M is the number of chapters, rather than issuing further DB calls.
 	async getHighlightsByBookTitle(
 		bookTitle: string,
-		sort: HighlightSort = "date",
+		sortByChapterProgress?: boolean,
+		sortByChapterOrder = true,
 	): Promise<Highlight[]> {
 		const [bookmarks, allContents] = await Promise.all([
-			this.repo.getBookmarksByBookTitle(bookTitle, sort),
+			this.repo.getBookmarksByBookTitle(bookTitle, sortByChapterProgress),
 			this.repo.getAllContentByBookTitleOrderedByContentId(bookTitle),
 		]);
 
@@ -98,11 +99,12 @@ export class HighlightService {
 			);
 		}
 
-		// For chapter/position sorts, order by VolumeIndex (the explicit EPUB
-		// spine index). This is immune to ContentID string-ordering quirks on
-		// books with non-sequential filenames. Within-chapter order comes from
-		// the SQL ORDER BY (DateCreated or ChapterProgress depending on sort).
-		if (sort === "chapter" || sort === "position") {
+		// If sortByChapterOrder is enabled, sort by VolumeIndex (the explicit
+		// EPUB spine index Kobo stores in the content table). This is immune to
+		// ContentID string-ordering quirks on books with non-sequential filenames.
+		// Fall back to ContentID comparison when VolumeIndex is absent.
+		// Highlights within the same chapter keep their SQL-determined order.
+		if (sortByChapterOrder) {
 			highlights.sort((a, b) => {
 				const aVol = a.content.volumeIndex;
 				const bVol = b.content.volumeIndex;
@@ -198,10 +200,13 @@ export class HighlightService {
 		return originalContent;
 	}
 
-	async getAllHighlight(sort: HighlightSort = "date"): Promise<Highlight[]> {
+	async getAllHighlight(
+		sortByChapterProgress?: boolean,
+		sortByChapterOrder?: boolean,
+	): Promise<Highlight[]> {
 		const highlights: Highlight[] = [];
 
-		const bookmarks = await this.repo.getAllBookmark(sort);
+		const bookmarks = await this.repo.getAllBookmark(sortByChapterProgress);
 		for (const bookmark of bookmarks) {
 			highlights.push(await this.createHighlightFromBookmark(bookmark));
 		}
@@ -216,7 +221,7 @@ export class HighlightService {
 			);
 			if (bookCmp !== 0) return bookCmp;
 
-			if (sort === "chapter" || sort === "position") {
+			if (sortByChapterOrder) {
 				const aVol = a.content.volumeIndex;
 				const bVol = b.content.volumeIndex;
 				if (aVol != null && bVol != null && aVol !== bVol)

--- a/src/database/Highlight.ts
+++ b/src/database/Highlight.ts
@@ -339,39 +339,46 @@ export class HighlightService {
 	//
 	// Strategy:
 	//   1. Word-count weighted — if WordCount is populated for at least one
-	//      spine item, use cumulative word counts as the position numerator and
-	//      total word count as the denominator. This correctly weights long
-	//      chapters as larger contributions than short ones.
-	//   2. Uniform fallback — when WordCount is entirely absent (all NULL/0),
-	//      fall back to (chapterIndex + chapterProgress) / totalChapters, which
-	//      is the old behaviour.
+	//      chapter, use cumulative word counts as the numerator and total word
+	//      count as the denominator. Long chapters contribute proportionally
+	//      more than short ones.
+	//   2. Uniform fallback — when WordCount is absent (all NULL/0), fall back
+	//      to (chapterIndex + chapterProgress) / totalChapters.
 	//
-	// In both cases chapterProgress (Kobo's within-spine-item fraction) is used
-	// to interpolate the position within the matched chapter.
+	// IMPORTANT: we restrict to rows where chapterIdBookmarked != null (actual
+	// chapter/spine entries). Kobo's content table also contains a top-level
+	// book row (ContentType 6) that often stores the *total* book word count in
+	// WordCount. Including it would double-count every word and shift all
+	// percentages into the upper half of the 0–1 range.
 	private calcBookProgress(
 		contentId: string,
 		chapterProgress: number | undefined,
 		allContents: Content[],
 	): number | undefined {
-		const idx = allContents.findIndex((c) => c.contentId === contentId);
+		// Only consider actual chapter entries.
+		const chapters = allContents.filter(
+			(c) => c.chapterIdBookmarked != null,
+		);
+
+		const idx = chapters.findIndex((c) => c.contentId === contentId);
 		if (idx === -1) return undefined;
 
 		const cp = chapterProgress ?? 0;
-		const totalWords = allContents.reduce(
+		const totalWords = chapters.reduce(
 			(sum, c) => sum + (c.wordCount ?? 0),
 			0,
 		);
 
 		if (totalWords > 0) {
 			// Word-count weighted path.
-			const wordsBeforeChapter = allContents
+			const wordsBeforeChapter = chapters
 				.slice(0, idx)
 				.reduce((sum, c) => sum + (c.wordCount ?? 0), 0);
-			const currentChapterWords = allContents[idx].wordCount ?? 0;
+			const currentChapterWords = chapters[idx].wordCount ?? 0;
 			return (wordsBeforeChapter + cp * currentChapterWords) / totalWords;
 		} else {
 			// Uniform fallback path.
-			const total = allContents.length;
+			const total = chapters.length;
 			if (total === 0) return undefined;
 			return (idx + cp) / total;
 		}

--- a/src/database/Highlight.ts
+++ b/src/database/Highlight.ts
@@ -109,22 +109,14 @@ export class HighlightService {
 			);
 		}
 
-		// Calculate reliable book-level progress using the sorted content list.
-		// Kobo's ChapterProgress is progress within a single EPUB spine item,
-		// which is 0→1 per chapter for multi-spine EPUBs but 0→1 for the whole
-		// book for single-spine EPUBs. bookProgress normalises across both cases.
-		const totalChapters = allContents.length;
-		if (totalChapters > 0) {
-			for (const h of highlights) {
-				const idx = allContents.findIndex(
-					(c) => c.contentId === h.content.contentId,
-				);
-				if (idx !== -1) {
-					h.bookmark.bookProgress =
-						(idx + (h.bookmark.chapterProgress ?? 0)) /
-						totalChapters;
-				}
-			}
+		// Calculate word-count-weighted book progress. Falls back to uniform
+		// chapter weighting when WordCount data is unavailable.
+		for (const h of highlights) {
+			h.bookmark.bookProgress = this.calcBookProgress(
+				h.content.contentId,
+				h.bookmark.chapterProgress,
+				allContents,
+			);
 		}
 
 		return highlights;
@@ -239,8 +231,8 @@ export class HighlightService {
 				: 0;
 		});
 
-		// Calculate bookProgress for every highlight. Cache per-book content
-		// queries so we only hit the DB once per unique book title.
+		// Calculate word-count-weighted book progress for every highlight.
+		// Cache per-book content queries so we only hit the DB once per book.
 		const contentsByBook = new Map<string, Content[]>();
 		for (const h of sorted) {
 			if (!h.content.bookTitle) continue;
@@ -252,15 +244,11 @@ export class HighlightService {
 					);
 				contentsByBook.set(h.content.bookTitle, contents);
 			}
-			const totalChapters = contents.length;
-			if (totalChapters === 0) continue;
-			const idx = contents.findIndex(
-				(c) => c.contentId === h.content.contentId,
+			h.bookmark.bookProgress = this.calcBookProgress(
+				h.content.contentId,
+				h.bookmark.chapterProgress,
+				contents,
 			);
-			if (idx !== -1) {
-				h.bookmark.bookProgress =
-					(idx + (h.bookmark.chapterProgress ?? 0)) / totalChapters;
-			}
 		}
 
 		return sorted;
@@ -344,6 +332,49 @@ export class HighlightService {
 		}
 
 		return originalContent;
+	}
+
+	// Calculates book-level progress (0–1) for a highlight given the ordered
+	// list of all content rows for its book.
+	//
+	// Strategy:
+	//   1. Word-count weighted — if WordCount is populated for at least one
+	//      spine item, use cumulative word counts as the position numerator and
+	//      total word count as the denominator. This correctly weights long
+	//      chapters as larger contributions than short ones.
+	//   2. Uniform fallback — when WordCount is entirely absent (all NULL/0),
+	//      fall back to (chapterIndex + chapterProgress) / totalChapters, which
+	//      is the old behaviour.
+	//
+	// In both cases chapterProgress (Kobo's within-spine-item fraction) is used
+	// to interpolate the position within the matched chapter.
+	private calcBookProgress(
+		contentId: string,
+		chapterProgress: number | undefined,
+		allContents: Content[],
+	): number | undefined {
+		const idx = allContents.findIndex((c) => c.contentId === contentId);
+		if (idx === -1) return undefined;
+
+		const cp = chapterProgress ?? 0;
+		const totalWords = allContents.reduce(
+			(sum, c) => sum + (c.wordCount ?? 0),
+			0,
+		);
+
+		if (totalWords > 0) {
+			// Word-count weighted path.
+			const wordsBeforeChapter = allContents
+				.slice(0, idx)
+				.reduce((sum, c) => sum + (c.wordCount ?? 0), 0);
+			const currentChapterWords = allContents[idx].wordCount ?? 0;
+			return (wordsBeforeChapter + cp * currentChapterWords) / totalWords;
+		} else {
+			// Uniform fallback path.
+			const total = allContents.length;
+			if (total === 0) return undefined;
+			return (idx + cp) / total;
+		}
 	}
 
 	async getAllBooks(): Promise<Map<string, BookDetails>> {

--- a/src/database/Highlight.ts
+++ b/src/database/Highlight.ts
@@ -75,7 +75,7 @@ export class HighlightService {
 	async getHighlightsByBookTitle(
 		bookTitle: string,
 		sortByChapterProgress?: boolean,
-		sortByChapterOrder?: boolean,
+		sortByChapterOrder = true,
 	): Promise<Highlight[]> {
 		const [bookmarks, allContents] = await Promise.all([
 			this.repo.getBookmarksByBookTitle(bookTitle, sortByChapterProgress),
@@ -197,6 +197,7 @@ export class HighlightService {
 
 	async getAllHighlight(
 		sortByChapterProgress?: boolean,
+		sortByChapterOrder?: boolean,
 	): Promise<Highlight[]> {
 		const highlights: Highlight[] = [];
 
@@ -205,15 +206,19 @@ export class HighlightService {
 			highlights.push(await this.createHighlightFromBookmark(bookmark));
 		}
 
-		return highlights.sort(function (a, b): number {
+		return highlights.sort((a, b) => {
 			if (!a.content.bookTitle || !b.content.bookTitle) {
 				throw new Error("bookTitle must be set");
 			}
 
-			return (
-				a.content.bookTitle.localeCompare(b.content.bookTitle) ||
-				a.content.contentId.localeCompare(b.content.contentId)
+			const bookCmp = a.content.bookTitle.localeCompare(
+				b.content.bookTitle,
 			);
+			if (bookCmp !== 0) return bookCmp;
+
+			return sortByChapterOrder
+				? a.content.contentId.localeCompare(b.content.contentId)
+				: 0;
 		});
 	}
 

--- a/src/database/Highlight.ts
+++ b/src/database/Highlight.ts
@@ -1,4 +1,4 @@
-import { BookDetails, Bookmark, Content, Highlight } from "./interfaces";
+import { BookDetails, Bookmark, Content, Highlight, HighlightSort } from "./interfaces";
 import { Repository } from "./repository";
 
 type bookTitle = string;
@@ -74,11 +74,10 @@ export class HighlightService {
 	//      where M is the number of chapters, rather than issuing further DB calls.
 	async getHighlightsByBookTitle(
 		bookTitle: string,
-		sortByChapterProgress?: boolean,
-		sortByChapterOrder = true,
+		sort: HighlightSort = "date",
 	): Promise<Highlight[]> {
 		const [bookmarks, allContents] = await Promise.all([
-			this.repo.getBookmarksByBookTitle(bookTitle, sortByChapterProgress),
+			this.repo.getBookmarksByBookTitle(bookTitle, sort),
 			this.repo.getAllContentByBookTitleOrderedByContentId(bookTitle),
 		]);
 
@@ -99,12 +98,11 @@ export class HighlightService {
 			);
 		}
 
-		// If sortByChapterOrder is enabled, sort by VolumeIndex (the explicit
-		// EPUB spine index Kobo stores in the content table). This is immune to
-		// ContentID string-ordering quirks on books with non-sequential filenames.
-		// Fall back to ContentID comparison when VolumeIndex is absent.
-		// Highlights within the same chapter keep their SQL-determined order.
-		if (sortByChapterOrder) {
+		// For chapter/position sorts, order by VolumeIndex (the explicit EPUB
+		// spine index). This is immune to ContentID string-ordering quirks on
+		// books with non-sequential filenames. Within-chapter order comes from
+		// the SQL ORDER BY (DateCreated or ChapterProgress depending on sort).
+		if (sort === "chapter" || sort === "position") {
 			highlights.sort((a, b) => {
 				const aVol = a.content.volumeIndex;
 				const bVol = b.content.volumeIndex;
@@ -200,18 +198,15 @@ export class HighlightService {
 		return originalContent;
 	}
 
-	async getAllHighlight(
-		sortByChapterProgress?: boolean,
-		sortByChapterOrder?: boolean,
-	): Promise<Highlight[]> {
+	async getAllHighlight(sort: HighlightSort = "date"): Promise<Highlight[]> {
 		const highlights: Highlight[] = [];
 
-		const bookmarks = await this.repo.getAllBookmark(sortByChapterProgress);
+		const bookmarks = await this.repo.getAllBookmark(sort);
 		for (const bookmark of bookmarks) {
 			highlights.push(await this.createHighlightFromBookmark(bookmark));
 		}
 
-		const sorted = highlights.sort((a, b) => {
+		return highlights.sort((a, b) => {
 			if (!a.content.bookTitle || !b.content.bookTitle) {
 				throw new Error("bookTitle must be set");
 			}
@@ -221,7 +216,7 @@ export class HighlightService {
 			);
 			if (bookCmp !== 0) return bookCmp;
 
-			if (sortByChapterOrder) {
+			if (sort === "chapter" || sort === "position") {
 				const aVol = a.content.volumeIndex;
 				const bVol = b.content.volumeIndex;
 				if (aVol != null && bVol != null && aVol !== bVol)
@@ -230,8 +225,6 @@ export class HighlightService {
 			}
 			return 0;
 		});
-
-		return sorted;
 	}
 
 	async createHighlightFromBookmark(bookmark: Bookmark): Promise<Highlight> {

--- a/src/database/interfaces.ts
+++ b/src/database/interfaces.ts
@@ -14,6 +14,7 @@ export interface Content {
 	contentId: string;
 	chapterIdBookmarked?: string;
 	bookTitle?: string;
+	wordCount?: number;
 }
 
 export interface Highlight {

--- a/src/database/interfaces.ts
+++ b/src/database/interfaces.ts
@@ -5,7 +5,7 @@ export interface Bookmark {
 	contentId: string;
 	note?: string;
 	dateCreated: Date;
-	chapterProgress?: number;
+	spineProgress?: number;
 }
 
 export interface Content {
@@ -13,6 +13,7 @@ export interface Content {
 	contentId: string;
 	chapterIdBookmarked?: string;
 	bookTitle?: string;
+	volumeIndex?: number;
 }
 
 export interface Highlight {

--- a/src/database/interfaces.ts
+++ b/src/database/interfaces.ts
@@ -5,6 +5,7 @@ export interface Bookmark {
 	contentId: string;
 	note?: string;
 	dateCreated: Date;
+	chapterProgress?: number;
 }
 
 export interface Content {

--- a/src/database/interfaces.ts
+++ b/src/database/interfaces.ts
@@ -6,6 +6,7 @@ export interface Bookmark {
 	note?: string;
 	dateCreated: Date;
 	chapterProgress?: number;
+	bookProgress?: number;
 }
 
 export interface Content {

--- a/src/database/interfaces.ts
+++ b/src/database/interfaces.ts
@@ -1,5 +1,4 @@
 /* eslint-disable no-unused-vars */
-export type HighlightSort = "date" | "chapter" | "position";
 export interface Bookmark {
 	bookmarkId: string;
 	text: string;

--- a/src/database/interfaces.ts
+++ b/src/database/interfaces.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-unused-vars */
+export type HighlightSort = "date" | "chapter" | "position";
 export interface Bookmark {
 	bookmarkId: string;
 	text: string;

--- a/src/database/interfaces.ts
+++ b/src/database/interfaces.ts
@@ -6,7 +6,6 @@ export interface Bookmark {
 	note?: string;
 	dateCreated: Date;
 	chapterProgress?: number;
-	bookProgress?: number;
 }
 
 export interface Content {
@@ -14,7 +13,6 @@ export interface Content {
 	contentId: string;
 	chapterIdBookmarked?: string;
 	bookTitle?: string;
-	wordCount?: number;
 }
 
 export interface Highlight {

--- a/src/database/repository.ts
+++ b/src/database/repository.ts
@@ -156,7 +156,7 @@ export class Repository {
 
 	async getAllContentByBookTitle(bookTitle: string): Promise<Content[]> {
 		const statement = this.db.prepare(
-			`select Title, ContentID, ChapterIDBookmarked, BookTitle, WordCount from "content" where BookTitle = $bookTitle`,
+			`select Title, ContentID, ChapterIDBookmarked, BookTitle from "content" where BookTitle = $bookTitle`,
 			{ $bookTitle: bookTitle },
 		);
 
@@ -170,7 +170,7 @@ export class Repository {
 		bookTitle: string,
 	): Promise<Content[]> {
 		const statement = this.db.prepare(
-			`select Title, ContentID, ChapterIDBookmarked, BookTitle, WordCount from "content" where BookTitle = $bookTitle order by "ContentID"`,
+			`select Title, ContentID, ChapterIDBookmarked, BookTitle from "content" where BookTitle = $bookTitle order by "ContentID"`,
 			{ $bookTitle: bookTitle },
 		);
 
@@ -354,16 +354,11 @@ export class Repository {
 
 		while (statement.step()) {
 			const row = statement.get();
-			const rawWordCount = row[4];
 			contents.push({
 				title: row[0]?.toString() ?? "",
 				contentId: row[1]?.toString() ?? "",
 				chapterIdBookmarked: row[2]?.toString(),
 				bookTitle: row[3]?.toString(),
-				wordCount:
-					rawWordCount != null && +rawWordCount > 0
-						? +rawWordCount
-						: undefined,
 			});
 		}
 

--- a/src/database/repository.ts
+++ b/src/database/repository.ts
@@ -156,7 +156,7 @@ export class Repository {
 
 	async getAllContentByBookTitle(bookTitle: string): Promise<Content[]> {
 		const statement = this.db.prepare(
-			`select Title, ContentID, ChapterIDBookmarked, BookTitle  from "content" where BookTitle = $bookTitle`,
+			`select Title, ContentID, ChapterIDBookmarked, BookTitle, WordCount from "content" where BookTitle = $bookTitle`,
 			{ $bookTitle: bookTitle },
 		);
 
@@ -170,7 +170,7 @@ export class Repository {
 		bookTitle: string,
 	): Promise<Content[]> {
 		const statement = this.db.prepare(
-			`select Title, ContentID, ChapterIDBookmarked, BookTitle  from "content" where BookTitle = $bookTitle order by "ContentID"`,
+			`select Title, ContentID, ChapterIDBookmarked, BookTitle, WordCount from "content" where BookTitle = $bookTitle order by "ContentID"`,
 			{ $bookTitle: bookTitle },
 		);
 
@@ -354,11 +354,16 @@ export class Repository {
 
 		while (statement.step()) {
 			const row = statement.get();
+			const rawWordCount = row[4];
 			contents.push({
 				title: row[0]?.toString() ?? "",
 				contentId: row[1]?.toString() ?? "",
 				chapterIdBookmarked: row[2]?.toString(),
 				bookTitle: row[3]?.toString(),
+				wordCount:
+					rawWordCount != null && +rawWordCount > 0
+						? +rawWordCount
+						: undefined,
 			});
 		}
 

--- a/src/database/repository.ts
+++ b/src/database/repository.ts
@@ -1,5 +1,5 @@
 import { Database, Statement } from "sql.js";
-import { BookDetails, Bookmark, Content } from "./interfaces";
+import { BookDetails, Bookmark, Content, HighlightSort } from "./interfaces";
 
 export class Repository {
 	db: Database;
@@ -8,17 +8,14 @@ export class Repository {
 		this.db = db;
 	}
 
-	async getAllBookmark(sortByChapterProgress?: boolean): Promise<Bookmark[]> {
-		let res;
-		if (sortByChapterProgress) {
-			res = this.db.exec(
-				`select BookmarkID, Text, ContentID, annotation, DateCreated, ChapterProgress from Bookmark where Text is not null order by ChapterProgress ASC, DateCreated ASC;`,
-			);
-		} else {
-			res = this.db.exec(
-				`select BookmarkID, Text, ContentID, annotation, DateCreated, ChapterProgress from Bookmark where Text is not null order by DateCreated ASC;`,
-			);
-		}
+	async getAllBookmark(sort: HighlightSort = "date"): Promise<Bookmark[]> {
+		const orderBy =
+			sort === "position"
+				? "ChapterProgress ASC, DateCreated ASC"
+				: "DateCreated ASC";
+		const res = this.db.exec(
+			`select BookmarkID, Text, ContentID, annotation, DateCreated, ChapterProgress from Bookmark where Text is not null order by ${orderBy};`,
+		);
 		const bookmarks: Bookmark[] = [];
 
 		if (res[0].values == undefined) {
@@ -223,11 +220,12 @@ export class Repository {
 
 	async getBookmarksByBookTitle(
 		bookTitle: string,
-		sortByChapterProgress?: boolean,
+		sort: HighlightSort = "date",
 	): Promise<Bookmark[]> {
-		const orderBy = sortByChapterProgress
-			? "b.ChapterProgress ASC, b.DateCreated ASC"
-			: "b.DateCreated ASC";
+		const orderBy =
+			sort === "position"
+				? "b.ChapterProgress ASC, b.DateCreated ASC"
+				: "b.DateCreated ASC";
 
 		// Use EXISTS with a parameterized bind to filter bookmarks to this book,
 		// handling both exact ContentID matches and fuzzy matches (where

--- a/src/database/repository.ts
+++ b/src/database/repository.ts
@@ -49,6 +49,7 @@ export class Repository {
 				contentId: row[2].toString(),
 				note: row[3]?.toString(),
 				dateCreated: new Date(row[4].toString()),
+				chapterProgress: row[5] != null ? +row[5] : undefined,
 			});
 		});
 
@@ -261,6 +262,7 @@ export class Repository {
 				contentId: row[2].toString(),
 				note: row[3]?.toString(),
 				dateCreated: new Date(row[4].toString()),
+				chapterProgress: row[5] != null ? +row[5] : undefined,
 			});
 		}
 

--- a/src/database/repository.ts
+++ b/src/database/repository.ts
@@ -220,6 +220,53 @@ export class Repository {
 		};
 	}
 
+	async getBookmarksByBookTitle(
+		bookTitle: string,
+		sortByChapterProgress?: boolean,
+	): Promise<Bookmark[]> {
+		const orderBy = sortByChapterProgress
+			? "b.ChapterProgress ASC, b.DateCreated ASC"
+			: "b.DateCreated ASC";
+
+		// Use EXISTS to filter bookmarks that belong to this book, handling both
+		// exact ContentID matches and fuzzy matches (where content.ContentID
+		// contains the bookmark's ContentID as a substring).
+		const res = this.db.exec(
+			`SELECT b.BookmarkID, b.Text, b.ContentID, b.annotation, b.DateCreated, b.ChapterProgress
+			FROM Bookmark b
+			WHERE b.Text IS NOT NULL
+			AND EXISTS (
+				SELECT 1 FROM content c
+				WHERE c.BookTitle = '${bookTitle.replace(/'/g, "''")}'
+				AND (c.ContentID = b.ContentID OR c.ContentID LIKE '%' || b.ContentID || '%')
+			)
+			ORDER BY ${orderBy};`,
+		);
+
+		const bookmarks: Bookmark[] = [];
+
+		if (!res[0]) {
+			return bookmarks;
+		}
+
+		res[0].values.forEach((row) => {
+			if (!(row[0] && row[1] && row[2] && row[4])) {
+				console.warn("Skipping bookmark with invalid values", row);
+				return;
+			}
+
+			bookmarks.push({
+				bookmarkId: row[0].toString(),
+				text: row[1].toString().replace(/\s+/g, " ").trim(),
+				contentId: row[2].toString(),
+				note: row[3]?.toString(),
+				dateCreated: new Date(row[4].toString()),
+			});
+		});
+
+		return bookmarks;
+	}
+
 	async getBookDetailsByIsbn(isbn: string): Promise<BookDetails | null> {
 		const statement = this.db.prepare(
 			`SELECT DISTINCT Title, Attribution as Author, Description, Publisher, DateLastRead, ReadStatus, ___PercentRead, ISBN, Series, SeriesNumber, TimeSpentReading FROM content WHERE ISBN = $isbn AND Title IS NOT NULL LIMIT 1;`,

--- a/src/database/repository.ts
+++ b/src/database/repository.ts
@@ -49,7 +49,7 @@ export class Repository {
 				contentId: row[2].toString(),
 				note: row[3]?.toString(),
 				dateCreated: new Date(row[4].toString()),
-				chapterProgress: row[5] != null ? +row[5] : undefined,
+				spineProgress: row[5] != null ? +row[5] : undefined,
 			});
 		});
 
@@ -156,7 +156,7 @@ export class Repository {
 
 	async getAllContentByBookTitle(bookTitle: string): Promise<Content[]> {
 		const statement = this.db.prepare(
-			`select Title, ContentID, ChapterIDBookmarked, BookTitle from "content" where BookTitle = $bookTitle`,
+			`select Title, ContentID, ChapterIDBookmarked, BookTitle, VolumeIndex from "content" where BookTitle = $bookTitle`,
 			{ $bookTitle: bookTitle },
 		);
 
@@ -170,7 +170,7 @@ export class Repository {
 		bookTitle: string,
 	): Promise<Content[]> {
 		const statement = this.db.prepare(
-			`select Title, ContentID, ChapterIDBookmarked, BookTitle from "content" where BookTitle = $bookTitle order by "ContentID"`,
+			`select Title, ContentID, ChapterIDBookmarked, BookTitle, VolumeIndex from "content" where BookTitle = $bookTitle order by "ContentID"`,
 			{ $bookTitle: bookTitle },
 		);
 
@@ -262,7 +262,7 @@ export class Repository {
 				contentId: row[2].toString(),
 				note: row[3]?.toString(),
 				dateCreated: new Date(row[4].toString()),
-				chapterProgress: row[5] != null ? +row[5] : undefined,
+				spineProgress: row[5] != null ? +row[5] : undefined,
 			});
 		}
 
@@ -359,6 +359,7 @@ export class Repository {
 				contentId: row[1]?.toString() ?? "",
 				chapterIdBookmarked: row[2]?.toString(),
 				bookTitle: row[3]?.toString(),
+				volumeIndex: row[4] != null ? +row[4] : undefined,
 			});
 		}
 

--- a/src/database/repository.ts
+++ b/src/database/repository.ts
@@ -228,31 +228,31 @@ export class Repository {
 			? "b.ChapterProgress ASC, b.DateCreated ASC"
 			: "b.DateCreated ASC";
 
-		// Use EXISTS to filter bookmarks that belong to this book, handling both
-		// exact ContentID matches and fuzzy matches (where content.ContentID
-		// contains the bookmark's ContentID as a substring).
-		const res = this.db.exec(
+		// Use EXISTS with a parameterized bind to filter bookmarks to this book,
+		// handling both exact ContentID matches and fuzzy matches (where
+		// content.ContentID contains the bookmark's ContentID as a substring).
+		// The ORDER BY clause uses an internally-derived string (not user input)
+		// so interpolating it is safe.
+		const statement = this.db.prepare(
 			`SELECT b.BookmarkID, b.Text, b.ContentID, b.annotation, b.DateCreated, b.ChapterProgress
 			FROM Bookmark b
 			WHERE b.Text IS NOT NULL
 			AND EXISTS (
 				SELECT 1 FROM content c
-				WHERE c.BookTitle = '${bookTitle.replace(/'/g, "''")}'
+				WHERE c.BookTitle = $bookTitle
 				AND (c.ContentID = b.ContentID OR c.ContentID LIKE '%' || b.ContentID || '%')
 			)
 			ORDER BY ${orderBy};`,
+			{ $bookTitle: bookTitle },
 		);
 
 		const bookmarks: Bookmark[] = [];
 
-		if (!res[0]) {
-			return bookmarks;
-		}
-
-		res[0].values.forEach((row) => {
+		while (statement.step()) {
+			const row = statement.get();
 			if (!(row[0] && row[1] && row[2] && row[4])) {
 				console.warn("Skipping bookmark with invalid values", row);
-				return;
+				continue;
 			}
 
 			bookmarks.push({
@@ -262,8 +262,9 @@ export class Repository {
 				note: row[3]?.toString(),
 				dateCreated: new Date(row[4].toString()),
 			});
-		});
+		}
 
+		statement.free();
 		return bookmarks;
 	}
 

--- a/src/database/repository.ts
+++ b/src/database/repository.ts
@@ -1,5 +1,5 @@
 import { Database, Statement } from "sql.js";
-import { BookDetails, Bookmark, Content, HighlightSort } from "./interfaces";
+import { BookDetails, Bookmark, Content } from "./interfaces";
 
 export class Repository {
 	db: Database;
@@ -8,11 +8,10 @@ export class Repository {
 		this.db = db;
 	}
 
-	async getAllBookmark(sort: HighlightSort = "date"): Promise<Bookmark[]> {
-		const orderBy =
-			sort === "position"
-				? "ChapterProgress ASC, DateCreated ASC"
-				: "DateCreated ASC";
+	async getAllBookmark(sortByChapterProgress?: boolean): Promise<Bookmark[]> {
+		const orderBy = sortByChapterProgress
+			? "ChapterProgress ASC, DateCreated ASC"
+			: "DateCreated ASC";
 		const res = this.db.exec(
 			`select BookmarkID, Text, ContentID, annotation, DateCreated, ChapterProgress from Bookmark where Text is not null order by ${orderBy};`,
 		);
@@ -220,12 +219,11 @@ export class Repository {
 
 	async getBookmarksByBookTitle(
 		bookTitle: string,
-		sort: HighlightSort = "date",
+		sortByChapterProgress?: boolean,
 	): Promise<Bookmark[]> {
-		const orderBy =
-			sort === "position"
-				? "b.ChapterProgress ASC, b.DateCreated ASC"
-				: "b.DateCreated ASC";
+		const orderBy = sortByChapterProgress
+			? "b.ChapterProgress ASC, b.DateCreated ASC"
+			: "b.DateCreated ASC";
 
 		// Use EXISTS with a parameterized bind to filter bookmarks to this book,
 		// handling both exact ContentID matches and fuzzy matches (where

--- a/src/database/repository.ts
+++ b/src/database/repository.ts
@@ -220,6 +220,39 @@ export class Repository {
 		};
 	}
 
+	async getBookDetailsByIsbn(isbn: string): Promise<BookDetails | null> {
+		const statement = this.db.prepare(
+			`SELECT DISTINCT Title, Attribution as Author, Description, Publisher, DateLastRead, ReadStatus, ___PercentRead, ISBN, Series, SeriesNumber, TimeSpentReading FROM content WHERE ISBN = $isbn AND Title IS NOT NULL LIMIT 1;`,
+			{ $isbn: isbn },
+		);
+
+		if (!statement.step()) {
+			statement.free();
+			return null;
+		}
+
+		const row = statement.get();
+		statement.free();
+
+		if (row[0] == null) {
+			return null;
+		}
+
+		return {
+			title: row[0].toString(),
+			author: row[1]?.toString() ?? "Unknown Author",
+			description: row[2]?.toString(),
+			publisher: row[3]?.toString(),
+			dateLastRead: row[4] ? new Date(row[4].toString()) : undefined,
+			readStatus: row[5] ? +row[5].toString() : 0,
+			percentRead: row[6] ? +row[6].toString() : 0,
+			isbn: row[7]?.toString(),
+			series: row[8]?.toString(),
+			seriesNumber: row[9] ? +row[9].toString() : undefined,
+			timeSpentReading: row[10] ? +row[10].toString() : 0,
+		};
+	}
+
 	async getAllBookDetails(): Promise<BookDetails[]> {
 		const statement = this.db.prepare(
 			`SELECT DISTINCT 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
-import { addIcon, Plugin } from "obsidian";
+import { addIcon, Notice, Plugin } from "obsidian";
+import { AppendHighlightsModal } from "./modal/AppendHighlightsModal";
 import { ExtractHighlightsModal } from "./modal/ExtractHighlightsModal";
 import {
 	DEFAULT_SETTINGS,
@@ -35,6 +36,40 @@ export default class KoboHighlightsImporter extends Plugin {
 				new ExtractHighlightsModal(this.app, this.settings).open();
 			},
 		});
+
+		this.addCommand({
+			id: "append-kobo-highlights-to-note",
+			name: "Append Kobo highlights to current note",
+			editorCallback: (editor, ctx) => {
+				if (!ctx.file) {
+					new Notice("No active file open");
+					return;
+				}
+				new AppendHighlightsModal(
+					this.app,
+					this.settings,
+					ctx.file,
+				).open();
+			},
+		});
+
+		const appendIconEl = this.addRibbonIcon(
+			"book-plus",
+			"Append Kobo highlights to current note",
+			() => {
+				const activeFile = this.app.workspace.getActiveFile();
+				if (!activeFile) {
+					new Notice("No active file open");
+					return;
+				}
+				new AppendHighlightsModal(
+					this.app,
+					this.settings,
+					activeFile,
+				).open();
+			},
+		);
+		appendIconEl.addClass("kobo-highlights-append-icon");
 
 		// This adds a settings tab so the user can configure various aspects of the plugin
 		this.addSettingTab(

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,24 +16,31 @@ export default class KoboHighlightsImporter extends Plugin {
 		addIcon("e-reader", EREADER_ICON_PATH);
 		await this.loadSettings();
 
+		const saveSettings = () => this.saveSettings();
+
 		// This creates an icon in the left ribbon.
 		const KoboHighlightsImporterIconEl = this.addRibbonIcon(
 			"e-reader",
 			"Import from Kobo",
 			() => {
-				// Called when the user clicks the icon.
-				new ExtractHighlightsModal(this.app, this.settings).open();
+				new ExtractHighlightsModal(
+					this.app,
+					this.settings,
+					saveSettings,
+				).open();
 			},
 		);
-		// Perform additional things with the ribbon
 		KoboHighlightsImporterIconEl.addClass("kobo-highlights-importer-icon");
 
-		// This adds a simple command that can be triggered anywhere
 		this.addCommand({
 			id: "import-from-kobo-sqlite",
 			name: "Import from Kobo",
 			callback: () => {
-				new ExtractHighlightsModal(this.app, this.settings).open();
+				new ExtractHighlightsModal(
+					this.app,
+					this.settings,
+					saveSettings,
+				).open();
 			},
 		});
 
@@ -49,6 +56,7 @@ export default class KoboHighlightsImporter extends Plugin {
 					this.app,
 					this.settings,
 					ctx.file,
+					saveSettings,
 				).open();
 			},
 		});
@@ -66,12 +74,12 @@ export default class KoboHighlightsImporter extends Plugin {
 					this.app,
 					this.settings,
 					activeFile,
+					saveSettings,
 				).open();
 			},
 		);
 		appendIconEl.addClass("kobo-highlights-append-icon");
 
-		// This adds a settings tab so the user can configure various aspects of the plugin
 		this.addSettingTab(
 			new KoboHighlightsImporterSettingsTab(this.app, this),
 		);

--- a/src/modal/AppendHighlightsModal.ts
+++ b/src/modal/AppendHighlightsModal.ts
@@ -51,8 +51,7 @@ export class AppendHighlightsModal extends Modal {
 	) {
 		const highlights = await service.getHighlightsByBookTitle(
 			bookTitle,
-			this.settings.sortByChapterProgress,
-			this.settings.sortByChapterOrder,
+			this.settings.highlightSort,
 		);
 
 		if (highlights.length === 0) {

--- a/src/modal/AppendHighlightsModal.ts
+++ b/src/modal/AppendHighlightsModal.ts
@@ -51,7 +51,8 @@ export class AppendHighlightsModal extends Modal {
 	) {
 		const highlights = await service.getHighlightsByBookTitle(
 			bookTitle,
-			this.settings.highlightSort,
+			this.settings.sortByChapterProgress,
+			this.settings.sortByChapterOrder,
 		);
 
 		if (highlights.length === 0) {

--- a/src/modal/AppendHighlightsModal.ts
+++ b/src/modal/AppendHighlightsModal.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "fs";
 import { App, Modal, Notice, TFile } from "obsidian";
 import SqlJs from "sql.js";
 import { binary } from "src/binaries/sql-wasm";
@@ -17,6 +18,7 @@ export class AppendHighlightsModal extends Modal {
 	inputFileEl!: HTMLInputElement;
 
 	settings: KoboHighlightsImporterSettings;
+	saveSettings: () => Promise<void>;
 	activeFile: TFile;
 
 	fileBuffer: ArrayBuffer | null | undefined;
@@ -25,9 +27,11 @@ export class AppendHighlightsModal extends Modal {
 		app: App,
 		settings: KoboHighlightsImporterSettings,
 		activeFile: TFile,
+		saveSettings: () => Promise<void>,
 	) {
 		super(app);
 		this.settings = settings;
+		this.saveSettings = saveSettings;
 		this.activeFile = activeFile;
 	}
 
@@ -103,7 +107,7 @@ export class AppendHighlightsModal extends Modal {
 		const db = new SQLEngine.Database(new Uint8Array(this.fileBuffer));
 		const service = new HighlightService(new Repository(db));
 
-		// Try ISBN match first
+		// Try ISBN match first.
 		const isbn = this.getFrontmatterValue("isbn");
 		if (isbn) {
 			const bookByIsbn = await service.getBookDetailsByIsbn(isbn);
@@ -113,7 +117,7 @@ export class AppendHighlightsModal extends Modal {
 			}
 		}
 
-		// Fall back to book picker
+		// Fall back to book picker.
 		const noteTitle =
 			this.getFrontmatterValue("title") ?? this.activeFile.basename;
 		const allBooks = await service.getAllBooks();
@@ -139,6 +143,32 @@ export class AppendHighlightsModal extends Modal {
 				}
 			},
 		).open();
+	}
+
+	private enableButton() {
+		this.goButtonEl.disabled = false;
+		this.goButtonEl.setAttr(
+			"style",
+			"background-color: green; color: black",
+		);
+	}
+
+	private tryLoadStoredPath() {
+		if (!this.settings.sqlitePath) return;
+
+		try {
+			const buf = readFileSync(this.settings.sqlitePath);
+			this.fileBuffer = buf.buffer.slice(
+				buf.byteOffset,
+				buf.byteOffset + buf.byteLength,
+			);
+			this.enableButton();
+			new Notice(`Loaded KoboReader.sqlite from remembered path`);
+		} catch {
+			new Notice(
+				`Could not load sqlite file from remembered path — please select it manually`,
+			);
+		}
 	}
 
 	onOpen() {
@@ -172,14 +202,17 @@ export class AppendHighlightsModal extends Modal {
 				return;
 			}
 
+			// Save the path for future sessions (Electron extends File with .path).
+			const filePath = (file as unknown as { path: string }).path;
+			if (filePath) {
+				this.settings.sqlitePath = filePath;
+				this.saveSettings();
+			}
+
 			const reader = new FileReader();
 			reader.onload = () => {
 				this.fileBuffer = reader.result as ArrayBuffer;
-				this.goButtonEl.disabled = false;
-				this.goButtonEl.setAttr(
-					"style",
-					"background-color: green; color: black",
-				);
+				this.enableButton();
 				new Notice("Ready to extract!");
 			};
 
@@ -202,6 +235,9 @@ export class AppendHighlightsModal extends Modal {
 		contentEl.appendChild(description);
 		contentEl.appendChild(this.inputFileEl);
 		contentEl.appendChild(this.goButtonEl);
+
+		// Try to auto-load from the remembered path after the UI is shown.
+		this.tryLoadStoredPath();
 	}
 
 	onClose() {

--- a/src/modal/AppendHighlightsModal.ts
+++ b/src/modal/AppendHighlightsModal.ts
@@ -1,3 +1,4 @@
+import { webUtils } from "electron";
 import { readFileSync } from "fs";
 import { App, Modal, Notice, TFile } from "obsidian";
 import SqlJs from "sql.js";
@@ -202,8 +203,8 @@ export class AppendHighlightsModal extends Modal {
 				return;
 			}
 
-			// Save the path for future sessions (Electron extends File with .path).
-			const filePath = (file as unknown as { path: string }).path;
+			// Save the path for future sessions using Electron's webUtils API.
+			const filePath = webUtils.getPathForFile(file);
 			if (filePath) {
 				this.settings.sqlitePath = filePath;
 				this.saveSettings();

--- a/src/modal/AppendHighlightsModal.ts
+++ b/src/modal/AppendHighlightsModal.ts
@@ -52,7 +52,7 @@ export class AppendHighlightsModal extends Modal {
 		const highlights = await service.getHighlightsByBookTitle(
 			bookTitle,
 			this.settings.sortByChapterProgress,
-			this.settings.appendSortByChapterOrder,
+			this.settings.sortByChapterOrder,
 		);
 
 		if (highlights.length === 0) {

--- a/src/modal/AppendHighlightsModal.ts
+++ b/src/modal/AppendHighlightsModal.ts
@@ -1,0 +1,211 @@
+import { App, Modal, Notice, TFile } from "obsidian";
+import SqlJs from "sql.js";
+import { binary } from "src/binaries/sql-wasm";
+import { HighlightService } from "src/database/Highlight";
+import { BookDetails } from "src/database/interfaces";
+import { Repository } from "src/database/repository";
+import { KoboHighlightsImporterSettings } from "src/settings/Settings";
+import {
+	applyTemplateTransformations,
+	defaultAppendTemplate,
+} from "src/template/template";
+import { getTemplateContents } from "src/template/templateContents";
+import { BookPickerModal } from "./BookPickerModal";
+
+export class AppendHighlightsModal extends Modal {
+	goButtonEl!: HTMLButtonElement;
+	inputFileEl!: HTMLInputElement;
+
+	settings: KoboHighlightsImporterSettings;
+	activeFile: TFile;
+
+	fileBuffer: ArrayBuffer | null | undefined;
+
+	constructor(
+		app: App,
+		settings: KoboHighlightsImporterSettings,
+		activeFile: TFile,
+	) {
+		super(app);
+		this.settings = settings;
+		this.activeFile = activeFile;
+	}
+
+	private getFrontmatterValue(key: string): string | undefined {
+		const cache = this.app.metadataCache.getFileCache(this.activeFile);
+		const value = cache?.frontmatter?.[key];
+		if (value && typeof value === "string" && value.trim()) {
+			return value.trim();
+		}
+		return undefined;
+	}
+
+	private async appendHighlightsForBook(
+		service: HighlightService,
+		bookTitle: string,
+	) {
+		const highlights = await service.getHighlightsByBookTitle(
+			bookTitle,
+			this.settings.sortByChapterProgress,
+		);
+
+		if (highlights.length === 0) {
+			new Notice(
+				`No highlights found for "${bookTitle}" in the Kobo database`,
+			);
+			return;
+		}
+
+		const contentMap = service.convertToMap(highlights);
+		const chapters = contentMap.get(bookTitle);
+
+		if (!chapters) {
+			new Notice(
+				`No highlights found for "${bookTitle}" in the Kobo database`,
+			);
+			return;
+		}
+
+		const details = await service.getBookDetailsFromBookTitle(bookTitle);
+
+		const template = await getTemplateContents(
+			this.app,
+			this.settings.appendTemplatePath,
+			defaultAppendTemplate,
+		);
+
+		const rendered = applyTemplateTransformations(
+			template,
+			chapters,
+			details,
+		);
+
+		const currentContent = await this.app.vault.read(this.activeFile);
+		await this.app.vault.modify(
+			this.activeFile,
+			currentContent + "\n\n" + rendered,
+		);
+
+		new Notice(
+			`Appended ${highlights.length} highlights from "${bookTitle}"`,
+		);
+	}
+
+	private async fetchAndAppendHighlights() {
+		if (!this.fileBuffer) {
+			throw new Error("No sqlite DB file selected...");
+		}
+
+		const SQLEngine = await SqlJs({
+			wasmBinary: binary.buffer,
+		});
+
+		const db = new SQLEngine.Database(new Uint8Array(this.fileBuffer));
+		const service = new HighlightService(new Repository(db));
+
+		// Try ISBN match first
+		const isbn = this.getFrontmatterValue("isbn");
+		if (isbn) {
+			const bookByIsbn = await service.getBookDetailsByIsbn(isbn);
+			if (bookByIsbn) {
+				await this.appendHighlightsForBook(service, bookByIsbn.title);
+				return;
+			}
+		}
+
+		// Fall back to book picker
+		const noteTitle =
+			this.getFrontmatterValue("title") ?? this.activeFile.basename;
+		const allBooks = await service.getAllBooks();
+		const bookList = Array.from(allBooks.values());
+
+		this.close();
+
+		new BookPickerModal(
+			this.app,
+			bookList,
+			noteTitle,
+			async (selected: BookDetails) => {
+				try {
+					await this.appendHighlightsForBook(
+						service,
+						selected.title,
+					);
+				} catch (e) {
+					console.error(e);
+					new Notice(
+						"Something went wrong... Check console for more details.",
+					);
+				}
+			},
+		).open();
+	}
+
+	onOpen() {
+		const { contentEl } = this;
+
+		this.goButtonEl = contentEl.createEl("button");
+		this.goButtonEl.textContent = "Append";
+		this.goButtonEl.disabled = true;
+		this.goButtonEl.setAttr("style", "background-color: red; color: white");
+		this.goButtonEl.addEventListener("click", () => {
+			new Notice("Extracting highlights...");
+			this.fetchAndAppendHighlights()
+				.then(() => {
+					this.close();
+				})
+				.catch((e) => {
+					console.error(e);
+					new Notice(
+						"Something went wrong... Check console for more details.",
+					);
+				});
+		});
+
+		this.inputFileEl = contentEl.createEl("input");
+		this.inputFileEl.type = "file";
+		this.inputFileEl.accept = ".sqlite";
+		this.inputFileEl.addEventListener("change", (ev) => {
+			const file = (ev.target as HTMLInputElement)?.files?.[0];
+			if (!file) {
+				console.error("No file selected");
+				return;
+			}
+
+			const reader = new FileReader();
+			reader.onload = () => {
+				this.fileBuffer = reader.result as ArrayBuffer;
+				this.goButtonEl.disabled = false;
+				this.goButtonEl.setAttr(
+					"style",
+					"background-color: green; color: black",
+				);
+				new Notice("Ready to extract!");
+			};
+
+			reader.onerror = (error) => {
+				console.error("FileReader error:", error);
+				new Notice("Error reading file");
+			};
+
+			reader.readAsArrayBuffer(file);
+		});
+
+		const heading = contentEl.createEl("h2");
+		heading.textContent = "Append Kobo Highlights";
+
+		const description = contentEl.createEl("p");
+		description.innerHTML =
+			"Please select your <em>KoboReader.sqlite</em> file from a connected device";
+
+		contentEl.appendChild(heading);
+		contentEl.appendChild(description);
+		contentEl.appendChild(this.inputFileEl);
+		contentEl.appendChild(this.goButtonEl);
+	}
+
+	onClose() {
+		const { contentEl } = this;
+		contentEl.empty();
+	}
+}

--- a/src/modal/AppendHighlightsModal.ts
+++ b/src/modal/AppendHighlightsModal.ts
@@ -52,6 +52,7 @@ export class AppendHighlightsModal extends Modal {
 		const highlights = await service.getHighlightsByBookTitle(
 			bookTitle,
 			this.settings.sortByChapterProgress,
+			this.settings.appendSortByChapterOrder,
 		);
 
 		if (highlights.length === 0) {

--- a/src/modal/BookPickerModal.ts
+++ b/src/modal/BookPickerModal.ts
@@ -1,0 +1,40 @@
+import { FuzzySuggestModal, App } from "obsidian";
+import { BookDetails } from "src/database/interfaces";
+
+export class BookPickerModal extends FuzzySuggestModal<BookDetails> {
+	private books: BookDetails[];
+	private onChoose: (book: BookDetails) => void;
+	private initialQuery: string;
+
+	constructor(
+		app: App,
+		books: BookDetails[],
+		initialQuery: string,
+		onChoose: (book: BookDetails) => void,
+	) {
+		super(app);
+		this.books = books;
+		this.onChoose = onChoose;
+		this.initialQuery = initialQuery;
+		this.setPlaceholder("Search for your book...");
+	}
+
+	onOpen() {
+		super.onOpen();
+		this.inputEl.value = this.initialQuery;
+		// Trigger the input event so the fuzzy search filters on the initial query
+		this.inputEl.dispatchEvent(new Event("input"));
+	}
+
+	getItems(): BookDetails[] {
+		return this.books;
+	}
+
+	getItemText(book: BookDetails): string {
+		return `${book.title} — ${book.author}`;
+	}
+
+	onChooseItem(book: BookDetails): void {
+		this.onChoose(book);
+	}
+}

--- a/src/modal/ExtractHighlightsModal.ts
+++ b/src/modal/ExtractHighlightsModal.ts
@@ -49,7 +49,10 @@ export class ExtractHighlightsModal extends Modal {
 		);
 
 		const content = service.convertToMap(
-			await service.getAllHighlight(this.settings.sortByChapterProgress),
+			await service.getAllHighlight(
+				this.settings.sortByChapterProgress,
+				this.settings.sortByChapterOrder,
+			),
 		);
 
 		const allBooksContent = new Map<string, Map<string, Bookmark[]>>();

--- a/src/modal/ExtractHighlightsModal.ts
+++ b/src/modal/ExtractHighlightsModal.ts
@@ -1,3 +1,4 @@
+import { webUtils } from "electron";
 import { readFileSync } from "fs";
 import { App, Modal, normalizePath, Notice } from "obsidian";
 import { sanitize } from "sanitize-filename-ts";
@@ -163,8 +164,8 @@ export class ExtractHighlightsModal extends Modal {
 				return;
 			}
 
-			// Save the path for future sessions (Electron extends File with .path).
-			const filePath = (file as unknown as { path: string }).path;
+			// Save the path for future sessions using Electron's webUtils API.
+			const filePath = webUtils.getPathForFile(file);
 			if (filePath) {
 				this.settings.sqlitePath = filePath;
 				this.saveSettings();

--- a/src/modal/ExtractHighlightsModal.ts
+++ b/src/modal/ExtractHighlightsModal.ts
@@ -49,10 +49,7 @@ export class ExtractHighlightsModal extends Modal {
 		);
 
 		const content = service.convertToMap(
-			await service.getAllHighlight(
-				this.settings.sortByChapterProgress,
-				this.settings.sortByChapterOrder,
-			),
+			await service.getAllHighlight(this.settings.highlightSort),
 		);
 
 		const allBooksContent = new Map<string, Map<string, Bookmark[]>>();

--- a/src/modal/ExtractHighlightsModal.ts
+++ b/src/modal/ExtractHighlightsModal.ts
@@ -49,7 +49,10 @@ export class ExtractHighlightsModal extends Modal {
 		);
 
 		const content = service.convertToMap(
-			await service.getAllHighlight(this.settings.highlightSort),
+			await service.getAllHighlight(
+				this.settings.sortByChapterProgress,
+				this.settings.sortByChapterOrder,
+			),
 		);
 
 		const allBooksContent = new Map<string, Map<string, Bookmark[]>>();

--- a/src/modal/ExtractHighlightsModal.ts
+++ b/src/modal/ExtractHighlightsModal.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "fs";
 import { App, Modal, normalizePath, Notice } from "obsidian";
 import { sanitize } from "sanitize-filename-ts";
 import SqlJs from "sql.js";
@@ -14,14 +15,20 @@ export class ExtractHighlightsModal extends Modal {
 	inputFileEl!: HTMLInputElement;
 
 	settings: KoboHighlightsImporterSettings;
+	saveSettings: () => Promise<void>;
 
 	fileBuffer: ArrayBuffer | null | undefined;
 
 	nrOfBooksExtracted: number;
 
-	constructor(app: App, settings: KoboHighlightsImporterSettings) {
+	constructor(
+		app: App,
+		settings: KoboHighlightsImporterSettings,
+		saveSettings: () => Promise<void>,
+	) {
 		super(app);
 		this.settings = settings;
+		this.saveSettings = saveSettings;
 		this.nrOfBooksExtracted = 0;
 	}
 
@@ -46,13 +53,11 @@ export class ExtractHighlightsModal extends Modal {
 
 		const allBooksContent = new Map<string, Map<string, Bookmark[]>>();
 
-		// Add all books with highlights
 		for (const [bookTitle, chapters] of content) {
 			allBooksContent.set(bookTitle, chapters);
 		}
 
 		if (this.settings.importAllBooks) {
-			// Add books without highlights
 			const allBooks = await service.getAllBooks();
 
 			for (const [bookTitle, _] of allBooks) {
@@ -94,6 +99,34 @@ export class ExtractHighlightsModal extends Modal {
 		}
 	}
 
+	private enableButton() {
+		this.goButtonEl.disabled = false;
+		this.goButtonEl.setAttr(
+			"style",
+			"background-color: green; color: black",
+		);
+	}
+
+	private tryLoadStoredPath() {
+		if (!this.settings.sqlitePath) return;
+
+		try {
+			const buf = readFileSync(this.settings.sqlitePath);
+			this.fileBuffer = buf.buffer.slice(
+				buf.byteOffset,
+				buf.byteOffset + buf.byteLength,
+			);
+			this.enableButton();
+			new Notice(
+				`Loaded KoboReader.sqlite from remembered path`,
+			);
+		} catch {
+			new Notice(
+				`Could not load sqlite file from remembered path — please select it manually`,
+			);
+		}
+	}
+
 	onOpen() {
 		const { contentEl } = this;
 
@@ -130,15 +163,17 @@ export class ExtractHighlightsModal extends Modal {
 				return;
 			}
 
-			// Convert File to ArrayBuffer
+			// Save the path for future sessions (Electron extends File with .path).
+			const filePath = (file as unknown as { path: string }).path;
+			if (filePath) {
+				this.settings.sqlitePath = filePath;
+				this.saveSettings();
+			}
+
 			const reader = new FileReader();
 			reader.onload = () => {
-				this.fileBuffer = reader.result as ArrayBuffer; // Store the ArrayBuffer
-				this.goButtonEl.disabled = false;
-				this.goButtonEl.setAttr(
-					"style",
-					"background-color: green; color: black",
-				);
+				this.fileBuffer = reader.result as ArrayBuffer;
+				this.enableButton();
 				new Notice("Ready to extract!");
 			};
 
@@ -161,6 +196,9 @@ export class ExtractHighlightsModal extends Modal {
 		contentEl.appendChild(description);
 		contentEl.appendChild(this.inputFileEl);
 		contentEl.appendChild(this.goButtonEl);
+
+		// Try to auto-load from the remembered path after the UI is shown.
+		this.tryLoadStoredPath();
 	}
 
 	onClose() {

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -7,6 +7,7 @@ export const DEFAULT_SETTINGS: KoboHighlightsImporterSettings = {
 	storageFolder: "",
 	sortByChapterProgress: false,
 	templatePath: "",
+	appendTemplatePath: "",
 	importAllBooks: false,
 };
 
@@ -14,6 +15,7 @@ export interface KoboHighlightsImporterSettings {
 	storageFolder: string;
 	sortByChapterProgress: boolean;
 	templatePath: string;
+	appendTemplatePath: string;
 	importAllBooks: boolean;
 }
 
@@ -31,6 +33,7 @@ export class KoboHighlightsImporterSettingsTab extends PluginSettingTab {
 
 		this.add_destination_folder();
 		this.add_template_path();
+		this.add_append_template_path();
 		this.add_sort_by_chapter_progress();
 		this.add_import_all_books();
 	}
@@ -60,6 +63,24 @@ export class KoboHighlightsImporterSettingsTab extends PluginSettingTab {
 					.setValue(this.plugin.settings.templatePath)
 					.onChange((newTemplatePath) => {
 						this.plugin.settings.templatePath = newTemplatePath;
+						this.plugin.saveSettings();
+					});
+			});
+	}
+
+	add_append_template_path(): void {
+		new Setting(this.containerEl)
+			.setName("Append Template Path")
+			.setDesc(
+				"Template used when appending highlights to an existing note",
+			)
+			.addSearch((cb) => {
+				new FileSuggestor(this.app, cb.inputEl);
+				cb.setPlaceholder("Example: folder1/append-template")
+					.setValue(this.plugin.settings.appendTemplatePath)
+					.onChange((newTemplatePath) => {
+						this.plugin.settings.appendTemplatePath =
+							newTemplatePath;
 						this.plugin.saveSettings();
 					});
 			});

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -9,6 +9,7 @@ export const DEFAULT_SETTINGS: KoboHighlightsImporterSettings = {
 	templatePath: "",
 	appendTemplatePath: "",
 	importAllBooks: false,
+	sqlitePath: "",
 };
 
 export interface KoboHighlightsImporterSettings {
@@ -17,6 +18,7 @@ export interface KoboHighlightsImporterSettings {
 	templatePath: string;
 	appendTemplatePath: string;
 	importAllBooks: boolean;
+	sqlitePath: string;
 }
 
 export class KoboHighlightsImporterSettingsTab extends PluginSettingTab {
@@ -32,6 +34,7 @@ export class KoboHighlightsImporterSettingsTab extends PluginSettingTab {
 		this.containerEl.createEl("h2", { text: this.plugin.manifest.name });
 
 		this.add_destination_folder();
+		this.add_sqlite_path();
 		this.add_template_path();
 		this.add_append_template_path();
 		this.add_sort_by_chapter_progress();
@@ -50,6 +53,26 @@ export class KoboHighlightsImporterSettingsTab extends PluginSettingTab {
 						this.plugin.settings.storageFolder = newFolder;
 						this.plugin.saveSettings();
 					});
+			});
+	}
+
+	add_sqlite_path(): void {
+		new Setting(this.containerEl)
+			.setName("Kobo SQLite path")
+			.setDesc(
+				"Remembered path to KoboReader.sqlite. Cleared automatically if the file is not found at this location.",
+			)
+			.addText((cb) => {
+				cb.setDisabled(true).setValue(
+					this.plugin.settings.sqlitePath || "(not set)",
+				);
+			})
+			.addButton((cb) => {
+				cb.setButtonText("Clear").onClick(async () => {
+					this.plugin.settings.sqlitePath = "";
+					await this.plugin.saveSettings();
+					this.display();
+				});
 			});
 	}
 

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -8,7 +8,7 @@ export const DEFAULT_SETTINGS: KoboHighlightsImporterSettings = {
 	sortByChapterProgress: false,
 	templatePath: "",
 	appendTemplatePath: "",
-	appendSortByChapterOrder: true,
+	sortByChapterOrder: true,
 	importAllBooks: false,
 	sqlitePath: "",
 };
@@ -18,7 +18,7 @@ export interface KoboHighlightsImporterSettings {
 	sortByChapterProgress: boolean;
 	templatePath: string;
 	appendTemplatePath: string;
-	appendSortByChapterOrder: boolean;
+	sortByChapterOrder: boolean;
 	importAllBooks: boolean;
 	sqlitePath: string;
 }
@@ -115,18 +115,18 @@ export class KoboHighlightsImporterSettingsTab extends PluginSettingTab {
 	add_append_sort_by_chapter_order(): void {
 		const desc = document.createDocumentFragment();
 		desc.append(
-			"When appending highlights to a note, sort chapters in reading order (by their position in the book). ",
+			"Sort chapters in reading order (by their position in the book). ",
 			"When disabled, chapters appear in the order you first highlighted in each one.",
 		);
 
 		new Setting(this.containerEl)
-			.setName("Append: sort chapters in reading order")
+			.setName("Sort chapters in reading order")
 			.setDesc(desc)
 			.addToggle((cb) => {
 				cb.setValue(
-					this.plugin.settings.appendSortByChapterOrder,
+					this.plugin.settings.sortByChapterOrder,
 				).onChange(async (toggle) => {
-					this.plugin.settings.appendSortByChapterOrder = toggle;
+					this.plugin.settings.sortByChapterOrder = toggle;
 					await this.plugin.saveSettings();
 				});
 			});

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -1,23 +1,24 @@
 import { App, PluginSettingTab, Setting } from "obsidian";
 import KoboHighlightsImporter from "src/main";
-import { HighlightSort } from "src/database/interfaces";
 import { FileSuggestor } from "./suggestors/FileSuggestor";
 import { FolderSuggestor } from "./suggestors/FolderSuggestor";
 
 export const DEFAULT_SETTINGS: KoboHighlightsImporterSettings = {
 	storageFolder: "",
-	highlightSort: "date",
+	sortByChapterProgress: false,
 	templatePath: "",
 	appendTemplatePath: "",
+	sortByChapterOrder: true,
 	importAllBooks: false,
 	sqlitePath: "",
 };
 
 export interface KoboHighlightsImporterSettings {
 	storageFolder: string;
-	highlightSort: HighlightSort;
+	sortByChapterProgress: boolean;
 	templatePath: string;
 	appendTemplatePath: string;
+	sortByChapterOrder: boolean;
 	importAllBooks: boolean;
 	sqlitePath: string;
 }
@@ -38,7 +39,8 @@ export class KoboHighlightsImporterSettingsTab extends PluginSettingTab {
 		this.add_sqlite_path();
 		this.add_template_path();
 		this.add_append_template_path();
-		this.add_highlight_sort();
+		this.add_sort_by_chapter_order();
+		this.add_sort_by_chapter_progress();
 		this.add_import_all_books();
 	}
 
@@ -110,24 +112,37 @@ export class KoboHighlightsImporterSettingsTab extends PluginSettingTab {
 			});
 	}
 
-	add_highlight_sort(): void {
+	add_sort_by_chapter_order(): void {
 		new Setting(this.containerEl)
-			.setName("Sort highlights")
+			.setName("Sort chapters in reading order")
 			.setDesc(
-				"Date created: chronological order. " +
-				"Reading order: chapters grouped by position in the book, highlights within each chapter by date. " +
-				"Reading order (by position): same grouping, but highlights within a chapter sorted by their position in the spine item.",
+				"Sort chapters by their position in the book. " +
+				"When disabled, chapters appear in the order you first highlighted in each one.",
 			)
-			.addDropdown((cb) => {
-				cb.addOption("date", "Date created")
-					.addOption("chapter", "Reading order")
-					.addOption("position", "Reading order (by position)")
-					.setValue(this.plugin.settings.highlightSort)
-					.onChange(async (value) => {
-						this.plugin.settings.highlightSort =
-							value as HighlightSort;
-						await this.plugin.saveSettings();
-					});
+			.addToggle((cb) => {
+				cb.setValue(
+					this.plugin.settings.sortByChapterOrder,
+				).onChange(async (toggle) => {
+					this.plugin.settings.sortByChapterOrder = toggle;
+					await this.plugin.saveSettings();
+				});
+			});
+	}
+
+	add_sort_by_chapter_progress(): void {
+		new Setting(this.containerEl)
+			.setName("Sort highlights by chapter progress")
+			.setDesc(
+				"Sort highlights by their position within the chapter. " +
+				"When disabled, highlights are sorted by creation date.",
+			)
+			.addToggle((cb) => {
+				cb.setValue(
+					this.plugin.settings.sortByChapterProgress,
+				).onChange(async (toggle) => {
+					this.plugin.settings.sortByChapterProgress = toggle;
+					await this.plugin.saveSettings();
+				});
 			});
 	}
 

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -8,6 +8,7 @@ export const DEFAULT_SETTINGS: KoboHighlightsImporterSettings = {
 	sortByChapterProgress: false,
 	templatePath: "",
 	appendTemplatePath: "",
+	appendSortByChapterOrder: true,
 	importAllBooks: false,
 	sqlitePath: "",
 };
@@ -17,6 +18,7 @@ export interface KoboHighlightsImporterSettings {
 	sortByChapterProgress: boolean;
 	templatePath: string;
 	appendTemplatePath: string;
+	appendSortByChapterOrder: boolean;
 	importAllBooks: boolean;
 	sqlitePath: string;
 }
@@ -37,6 +39,7 @@ export class KoboHighlightsImporterSettingsTab extends PluginSettingTab {
 		this.add_sqlite_path();
 		this.add_template_path();
 		this.add_append_template_path();
+		this.add_append_sort_by_chapter_order();
 		this.add_sort_by_chapter_progress();
 		this.add_import_all_books();
 	}
@@ -106,6 +109,26 @@ export class KoboHighlightsImporterSettingsTab extends PluginSettingTab {
 							newTemplatePath;
 						this.plugin.saveSettings();
 					});
+			});
+	}
+
+	add_append_sort_by_chapter_order(): void {
+		const desc = document.createDocumentFragment();
+		desc.append(
+			"When appending highlights to a note, sort chapters in reading order (by their position in the book). ",
+			"When disabled, chapters appear in the order you first highlighted in each one.",
+		);
+
+		new Setting(this.containerEl)
+			.setName("Append: sort chapters in reading order")
+			.setDesc(desc)
+			.addToggle((cb) => {
+				cb.setValue(
+					this.plugin.settings.appendSortByChapterOrder,
+				).onChange(async (toggle) => {
+					this.plugin.settings.appendSortByChapterOrder = toggle;
+					await this.plugin.saveSettings();
+				});
 			});
 	}
 

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -1,24 +1,23 @@
 import { App, PluginSettingTab, Setting } from "obsidian";
 import KoboHighlightsImporter from "src/main";
+import { HighlightSort } from "src/database/interfaces";
 import { FileSuggestor } from "./suggestors/FileSuggestor";
 import { FolderSuggestor } from "./suggestors/FolderSuggestor";
 
 export const DEFAULT_SETTINGS: KoboHighlightsImporterSettings = {
 	storageFolder: "",
-	sortByChapterProgress: false,
+	highlightSort: "date",
 	templatePath: "",
 	appendTemplatePath: "",
-	sortByChapterOrder: true,
 	importAllBooks: false,
 	sqlitePath: "",
 };
 
 export interface KoboHighlightsImporterSettings {
 	storageFolder: string;
-	sortByChapterProgress: boolean;
+	highlightSort: HighlightSort;
 	templatePath: string;
 	appendTemplatePath: string;
-	sortByChapterOrder: boolean;
 	importAllBooks: boolean;
 	sqlitePath: string;
 }
@@ -39,8 +38,7 @@ export class KoboHighlightsImporterSettingsTab extends PluginSettingTab {
 		this.add_sqlite_path();
 		this.add_template_path();
 		this.add_append_template_path();
-		this.add_append_sort_by_chapter_order();
-		this.add_sort_by_chapter_progress();
+		this.add_highlight_sort();
 		this.add_import_all_books();
 	}
 
@@ -112,42 +110,24 @@ export class KoboHighlightsImporterSettingsTab extends PluginSettingTab {
 			});
 	}
 
-	add_append_sort_by_chapter_order(): void {
-		const desc = document.createDocumentFragment();
-		desc.append(
-			"Sort chapters in reading order (by their position in the book). ",
-			"When disabled, chapters appear in the order you first highlighted in each one.",
-		);
-
+	add_highlight_sort(): void {
 		new Setting(this.containerEl)
-			.setName("Sort chapters in reading order")
-			.setDesc(desc)
-			.addToggle((cb) => {
-				cb.setValue(
-					this.plugin.settings.sortByChapterOrder,
-				).onChange(async (toggle) => {
-					this.plugin.settings.sortByChapterOrder = toggle;
-					await this.plugin.saveSettings();
-				});
-			});
-	}
-
-	add_sort_by_chapter_progress(): void {
-		const desc = document.createDocumentFragment();
-		desc.append(
-			"Turn on to sort highlights by chapter progess. If turned off, highlights are sorted by creation date and time.",
-		);
-
-		new Setting(this.containerEl)
-			.setName("Sort by chapter progress")
-			.setDesc(desc)
-			.addToggle((cb) => {
-				cb.setValue(
-					this.plugin.settings.sortByChapterProgress,
-				).onChange((toggle) => {
-					this.plugin.settings.sortByChapterProgress = toggle;
-					this.plugin.saveSettings();
-				});
+			.setName("Sort highlights")
+			.setDesc(
+				"Date created: chronological order. " +
+				"Reading order: chapters grouped by position in the book, highlights within each chapter by date. " +
+				"Reading order (by position): same grouping, but highlights within a chapter sorted by their position in the spine item.",
+			)
+			.addDropdown((cb) => {
+				cb.addOption("date", "Date created")
+					.addOption("chapter", "Reading order")
+					.addOption("position", "Reading order (by position)")
+					.setValue(this.plugin.settings.highlightSort)
+					.onChange(async (value) => {
+						this.plugin.settings.highlightSort =
+							value as HighlightSort;
+						await this.plugin.saveSettings();
+					});
 			});
 	}
 

--- a/src/template/template.ts
+++ b/src/template/template.ts
@@ -37,7 +37,7 @@ timeSpentReading: <%= it.bookDetails.timeSpentReading ?? '' %>
 
 <% } -%>
 <% if (highlight.dateCreated) { -%>
-*<%= highlight.dateCreated.toISOString() %><% if (highlight.bookProgress != null) { %> · <%= (highlight.bookProgress * 100).toFixed(1) %>%<% } %>*
+*<%= highlight.dateCreated.toISOString() %>*
 
 <% } -%>
 <% }) -%>
@@ -58,7 +58,7 @@ export const defaultAppendTemplate = `
 
 <% } -%>
 <% if (highlight.dateCreated) { -%>
-*<%= highlight.dateCreated.toISOString() %><% if (highlight.bookProgress != null) { %> · <%= (highlight.bookProgress * 100).toFixed(1) %>%<% } %>*
+*<%= highlight.dateCreated.toISOString() %>*
 
 <% } -%>
 <% }) -%>

--- a/src/template/template.ts
+++ b/src/template/template.ts
@@ -58,7 +58,7 @@ export const defaultAppendTemplate = `
 
 <% } -%>
 <% if (highlight.dateCreated) { -%>
-*Created: <%= highlight.dateCreated.toISOString() %>*
+*<%= highlight.dateCreated.toISOString() %><% if (highlight.chapterProgress != null) { %> · <%= (highlight.chapterProgress * 100).toFixed(0) %>%<% } %>*
 
 <% } -%>
 <% }) -%>

--- a/src/template/template.ts
+++ b/src/template/template.ts
@@ -37,7 +37,7 @@ timeSpentReading: <%= it.bookDetails.timeSpentReading ?? '' %>
 
 <% } -%>
 <% if (highlight.dateCreated) { -%>
-*<%= highlight.dateCreated.toISOString() %><% if (highlight.chapterProgress != null) { %> · <%= (highlight.chapterProgress * 100).toFixed(0) %>%<% } %>*
+*<%= highlight.dateCreated.toISOString() %><% if (highlight.bookProgress != null) { %> · <%= (highlight.bookProgress * 100).toFixed(0) %>%<% } %>*
 
 <% } -%>
 <% }) -%>
@@ -58,7 +58,7 @@ export const defaultAppendTemplate = `
 
 <% } -%>
 <% if (highlight.dateCreated) { -%>
-*<%= highlight.dateCreated.toISOString() %><% if (highlight.chapterProgress != null) { %> · <%= (highlight.chapterProgress * 100).toFixed(0) %>%<% } %>*
+*<%= highlight.dateCreated.toISOString() %><% if (highlight.bookProgress != null) { %> · <%= (highlight.bookProgress * 100).toFixed(0) %>%<% } %>*
 
 <% } -%>
 <% }) -%>

--- a/src/template/template.ts
+++ b/src/template/template.ts
@@ -44,6 +44,27 @@ timeSpentReading: <%= it.bookDetails.timeSpentReading ?? '' %>
 <% }) %>
 `;
 
+export const defaultAppendTemplate = `
+## Highlights
+
+<% it.chapters.forEach(([chapterName, highlights]) => { -%>
+### <%= chapterName.trim() %>
+
+<% highlights.forEach((highlight) => { -%>
+<%= highlight.text %>
+
+<% if (highlight.note) { -%>
+**Note:** <%= highlight.note %>
+
+<% } -%>
+<% if (highlight.dateCreated) { -%>
+*Created: <%= highlight.dateCreated.toISOString() %>*
+
+<% } -%>
+<% }) -%>
+<% }) %>
+`;
+
 export function applyTemplateTransformations(
 	rawTemplate: string,
 	chapters: Map<chapter, Bookmark[]>,

--- a/src/template/template.ts
+++ b/src/template/template.ts
@@ -37,7 +37,7 @@ timeSpentReading: <%= it.bookDetails.timeSpentReading ?? '' %>
 
 <% } -%>
 <% if (highlight.dateCreated) { -%>
-*<%= highlight.dateCreated.toISOString() %><% if (highlight.bookProgress != null) { %> · <%= (highlight.bookProgress * 100).toFixed(0) %>%<% } %>*
+*<%= highlight.dateCreated.toISOString() %><% if (highlight.bookProgress != null) { %> · <%= (highlight.bookProgress * 100).toFixed(1) %>%<% } %>*
 
 <% } -%>
 <% }) -%>
@@ -58,7 +58,7 @@ export const defaultAppendTemplate = `
 
 <% } -%>
 <% if (highlight.dateCreated) { -%>
-*<%= highlight.dateCreated.toISOString() %><% if (highlight.bookProgress != null) { %> · <%= (highlight.bookProgress * 100).toFixed(0) %>%<% } %>*
+*<%= highlight.dateCreated.toISOString() %><% if (highlight.bookProgress != null) { %> · <%= (highlight.bookProgress * 100).toFixed(1) %>%<% } %>*
 
 <% } -%>
 <% }) -%>

--- a/src/template/template.ts
+++ b/src/template/template.ts
@@ -37,7 +37,7 @@ timeSpentReading: <%= it.bookDetails.timeSpentReading ?? '' %>
 
 <% } -%>
 <% if (highlight.dateCreated) { -%>
-*Created: <%= highlight.dateCreated.toISOString() %>*
+*<%= highlight.dateCreated.toISOString() %><% if (highlight.chapterProgress != null) { %> · <%= (highlight.chapterProgress * 100).toFixed(0) %>%<% } %>*
 
 <% } -%>
 <% }) -%>

--- a/src/template/templateContents.ts
+++ b/src/template/templateContents.ts
@@ -6,11 +6,12 @@ import { defaultTemplate } from "./template";
 export async function getTemplateContents(
 	app: App,
 	templatePath: string | undefined,
+	fallback: string = defaultTemplate,
 ): Promise<string> {
 	const { metadataCache, vault } = app;
 	const normalizedTemplatePath = normalizePath(templatePath ?? "");
 	if (normalizedTemplatePath === "/") {
-		return defaultTemplate;
+		return fallback;
 	}
 
 	try {
@@ -18,7 +19,7 @@ export async function getTemplateContents(
 			normalizedTemplatePath,
 			"",
 		);
-		return templateFile ? vault.cachedRead(templateFile) : defaultTemplate;
+		return templateFile ? vault.cachedRead(templateFile) : fallback;
 	} catch (err) {
 		console.error(
 			`Failed to read the kobo highlight exporter template '${normalizedTemplatePath}'`,

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -1,0 +1,5 @@
+declare module "electron" {
+	export const webUtils: {
+		getPathForFile(file: File): string;
+	};
+}


### PR DESCRIPTION
## Summary

- **Append highlights to current note**: new command and ribbon icon that reads the active note's `title` frontmatter (or filename as fallback), matches against the Kobo database by ISBN first then a fuzzy book picker, and appends highlights using a dedicated append template
- **SQLite path persistence**: both modals remember the last-used `KoboReader.sqlite` path and auto-load it on open; path is saved via Electron's `webUtils.getPathForFile` API and cleared gracefully if the file moves
- **Single-book query optimisation**: replaced the naive fetch-all-then-filter approach with a targeted 2-query path (bookmarks filtered by book + all content for that book), resolving content associations in-memory — significantly faster on large libraries
- **Chapter sort setting**: new "Sort chapters in reading order" toggle uses `VolumeIndex` from the content table (Kobo's explicit EPUB spine index) instead of ContentID string comparison, fixing wrong order on books with non-sequential filenames; applies to both commands
- **Spine progress exposure**: `Bookmark.spineProgress` (Kobo's `ChapterProgress` field) is available in custom templates as `highlight.spineProgress`; renamed from `chapterProgress` to reflect that it represents within-spine-item progress, which is chapter-level for multi-spine EPUBs and book-level for single-spine EPUBs
- **Append template path setting**: separate template path for the append workflow
- **Book picker modal**: `FuzzySuggestModal` pre-filtered by the note title, used as fallback when ISBN match fails

## Test plan

- [ ] Open a note with a `title` frontmatter matching a Kobo book → trigger "Append Kobo highlights to current note" → highlights appended correctly
- [ ] Open a note whose title doesn't exactly match → book picker opens pre-filtered → selecting a book appends correctly
- [ ] Open a note with `isbn` frontmatter → ISBN match bypasses picker
- [ ] Select SQLite file in either modal → path remembered → reopen modal → file auto-loaded
- [ ] Move/delete the SQLite file → reopen modal → graceful notice shown, file picker still works
- [ ] Enable "Sort chapters in reading order" → verify chapters appear in book order for a book that previously sorted wrong
- [ ] Enable "Sort by chapter progress" → verify highlights within each chapter sorted by spine position
- [ ] Both sort toggles enabled simultaneously → chapter order + within-chapter spine order
- [ ] Existing "Extract all highlights" command still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)