### PR TITLE
fix: sort chapters by EPUB spine position (VolumeIndex)

### DIFF
--- a/src/database/Highlight.ts
+++ b/src/database/Highlight.ts
@@ -66,15 +66,28 @@ export class HighlightService {
 			highlights.push(await this.createHighlightFromBookmark(bookmark));
 		}
 
-		return highlights.sort(function (a, b): number {
+		return highlights.sort((a, b) => {
 			if (!a.content.bookTitle || !b.content.bookTitle) {
 				throw new Error("bookTitle must be set");
 			}
 
-			return (
-				a.content.bookTitle.localeCompare(b.content.bookTitle) ||
-				a.content.contentId.localeCompare(b.content.contentId)
+			const bookCmp = a.content.bookTitle.localeCompare(
+				b.content.bookTitle,
 			);
+			if (bookCmp !== 0) return bookCmp;
+
+			// Sort chapters by VolumeIndex (the EPUB spine index Kobo stores in
+			// the content table). This is the authoritative reading order and
+			// supersedes ContentID alphanumeric sort, which can mis-order books
+			// with non-sequential filenames (e.g. chapter9.xhtml > chapter10.xhtml).
+			// Null-safe: entries without VolumeIndex fall back to ContentID,
+			// preserving existing behaviour for books that lack spine data.
+			const aVol = a.content.volumeIndex;
+			const bVol = b.content.volumeIndex;
+			if (aVol != null && bVol != null) return aVol - bVol;
+			if (aVol != null) return -1;
+			if (bVol != null) return 1;
+			return a.content.contentId.localeCompare(b.content.contentId);
 		});
 	}
 

--- a/src/database/Highlight.ts
+++ b/src/database/Highlight.ts
@@ -56,6 +56,15 @@ export class HighlightService {
 		return m;
 	}
 
+	/**
+	 * Returns all highlights sorted by book title, then by chapter order.
+	 * Within each book, chapters are ordered by VolumeIndex — the EPUB spine
+	 * index Kobo stores in the content table. This is the authoritative reading
+	 * order and supersedes ContentID alphanumeric sort, which can mis-order
+	 * books with non-sequential filenames (e.g. chapter9.xhtml > chapter10.xhtml).
+	 * Null-safe: entries without VolumeIndex fall back to ContentID, preserving
+	 * existing behaviour for books that lack spine data.
+	 */
 	async getAllHighlight(
 		sortByChapterProgress?: boolean,
 	): Promise<Highlight[]> {
@@ -76,12 +85,6 @@ export class HighlightService {
 			);
 			if (bookCmp !== 0) return bookCmp;
 
-			// Sort chapters by VolumeIndex (the EPUB spine index Kobo stores in
-			// the content table). This is the authoritative reading order and
-			// supersedes ContentID alphanumeric sort, which can mis-order books
-			// with non-sequential filenames (e.g. chapter9.xhtml > chapter10.xhtml).
-			// Null-safe: entries without VolumeIndex fall back to ContentID,
-			// preserving existing behaviour for books that lack spine data.
 			const aVol = a.content.volumeIndex;
 			const bVol = b.content.volumeIndex;
 			if (aVol != null && bVol != null) return aVol - bVol;

--- a/src/database/interfaces.ts
+++ b/src/database/interfaces.ts
@@ -12,6 +12,7 @@ export interface Content {
 	contentId: string;
 	chapterIdBookmarked?: string;
 	bookTitle?: string;
+	volumeIndex?: number;
 }
 
 export interface Highlight {

--- a/src/database/repository.ts
+++ b/src/database/repository.ts
@@ -92,8 +92,8 @@ export class Repository {
 
 	async getContentByContentId(contentId: string): Promise<Content | null> {
 		const statement = this.db.prepare(
-			`select 
-                Title, ContentID, ChapterIDBookmarked, BookTitle from content
+			`select
+                Title, ContentID, ChapterIDBookmarked, BookTitle, VolumeIndex from content
                 where ContentID = $id;`,
 			{ $id: contentId },
 		);
@@ -111,8 +111,8 @@ export class Repository {
 
 	async getContentLikeContentId(contentId: string): Promise<Content | null> {
 		const statement = this.db.prepare(
-			`select 
-                Title, ContentID, ChapterIDBookmarked, BookTitle from content
+			`select
+                Title, ContentID, ChapterIDBookmarked, BookTitle, VolumeIndex from content
                 where ContentID like $id;`,
 			{ $id: `%${contentId}%` },
 		);
@@ -130,8 +130,8 @@ export class Repository {
 
 	async getFirstContentLikeContentIdWithBookmarkIdNotNull(contentId: string) {
 		const statement = this.db.prepare(
-			`select 
-                Title, ContentID, ChapterIDBookmarked, BookTitle from "content" 
+			`select
+                Title, ContentID, ChapterIDBookmarked, BookTitle, VolumeIndex from "content"
                 where "ContentID" like $id and "ChapterIDBookmarked" not NULL limit 1`,
 			{ $id: `${contentId}%` },
 		);
@@ -143,7 +143,7 @@ export class Repository {
 
 	async getAllContent(limit = 100): Promise<Content[]> {
 		const statement = this.db.prepare(
-			`select Title, ContentID, ChapterIDBookmarked, BookTitle from content limit $limit`,
+			`select Title, ContentID, ChapterIDBookmarked, BookTitle, VolumeIndex from content limit $limit`,
 			{ $limit: limit },
 		);
 
@@ -155,7 +155,7 @@ export class Repository {
 
 	async getAllContentByBookTitle(bookTitle: string): Promise<Content[]> {
 		const statement = this.db.prepare(
-			`select Title, ContentID, ChapterIDBookmarked, BookTitle  from "content" where BookTitle = $bookTitle`,
+			`select Title, ContentID, ChapterIDBookmarked, BookTitle, VolumeIndex from "content" where BookTitle = $bookTitle`,
 			{ $bookTitle: bookTitle },
 		);
 
@@ -169,7 +169,7 @@ export class Repository {
 		bookTitle: string,
 	): Promise<Content[]> {
 		const statement = this.db.prepare(
-			`select Title, ContentID, ChapterIDBookmarked, BookTitle  from "content" where BookTitle = $bookTitle order by "ContentID"`,
+			`select Title, ContentID, ChapterIDBookmarked, BookTitle, VolumeIndex from "content" where BookTitle = $bookTitle order by "ContentID"`,
 			{ $bookTitle: bookTitle },
 		);
 
@@ -276,6 +276,7 @@ export class Repository {
 				contentId: row[1]?.toString() ?? "",
 				chapterIdBookmarked: row[2]?.toString(),
 				bookTitle: row[3]?.toString(),
+				volumeIndex: row[4] != null ? +row[4] : undefined,
 			});
 		}
 


### PR DESCRIPTION
Changes chapter sorting to always be in reading order, addressing inconsistent chapter ordering. Part of a set of changes I made to the plugin with Claude Code to improve my Obsidian workflow.

---

## Summary

Highlights were being grouped into chapters whose order was determined by
`contentId.localeCompare()` — an alphanumeric sort on an opaque internal
identifier. For most readers this happens to approximate reading order, but
it breaks whenever chapters are highlighted out of sequence or when an
EPUB's ContentIDs are not assigned in spine order.

This fix reads the `VolumeIndex` column that the Kobo firmware already writes
to the `content` table to record a chapter's position in the EPUB spine, and
uses it as the primary sort key. ContentID is kept as a fallback for books
that don't populate VolumeIndex.

The previous `Sort by chapter progress` toggle controlled a different axis
(sort highlights *within* a chapter by their position in the text vs. by
creation date). It had no effect on chapter *order*, which this PR addresses.
That toggle is preserved unchanged.

## Changes

- `src/database/interfaces.ts` — add `volumeIndex?: number` to `Content`
- `src/database/repository.ts` — add `VolumeIndex` to all `content` SELECT
  queries; populate `volumeIndex` in `parseContentStatement`
- `src/database/Highlight.ts` — replace ContentID alphanumeric sort with
  VolumeIndex sort (null-safe: falls back to ContentID for books without it)

## Behaviour change

Only visible when a book's chapters were highlighted out of reading order,
or when the EPUB's ContentIDs happen not to be in spine order. For the
vast majority of imported books the output is identical to before.

## Related

- Closes #461 — highlights appear in wrong chapter order  
- Related to #361  
- See also PR #471 (sorts by `FileOffset` — an alternative signal; a tester
  reported imperfect results) and PR #477 (depth-aware `ChapterEntry[]` tree;
  maintainer requested changes). This PR uses `VolumeIndex`, the field the
  firmware explicitly maintains for spine position, and keeps the change
  minimal — no new data structures or settings.

---

> **Note:** The implementation in this PR was developed with AI assistance
> (Claude). The logic has been manually reviewed and tested against a real
> Kobo device, but please flag anything that looks wrong.