### PR TITLE
fix: deduplicate repeated chapter names in output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,13 @@
 
 ## [5.0.0](https://github.com/OGKevin/obsidian-kobo-highlights-import/compare/4.1.0...5.0.0) (2026-02-19)
 
-
 ### ⚠ BREAKING CHANGES
 
-* add eta templating engine and update template logic
+- add eta templating engine and update template logic
 
 ### Features
 
-* add eta templating engine and update template logic ([53a8641](https://github.com/OGKevin/obsidian-kobo-highlights-import/commit/53a86412ee566a14e6501ed57b61316321189c3d))
+- add eta templating engine and update template logic ([53a8641](https://github.com/OGKevin/obsidian-kobo-highlights-import/commit/53a86412ee566a14e6501ed57b61316321189c3d))
 
 ## [4.1.0](https://github.com/OGKevin/obsidian-kobo-highlights-import/compare/4.0.0...4.1.0) (2025-09-04)
 

--- a/src/database/Highlight.ts
+++ b/src/database/Highlight.ts
@@ -193,4 +193,24 @@ export class HighlightService {
 	createEmptyContentMap(): Map<chapter, Bookmark[]> {
 		return new Map<chapter, Bookmark[]>();
 	}
+
+	buildChapterList(highlights: Highlight[]): [chapter, Bookmark[]][] {
+		const chapters: [chapter, Bookmark[]][] = [];
+		const contentIdToIndex = new Map<string, number>();
+
+		for (const h of highlights) {
+			const { title, contentId } = h.content;
+			let idx = contentIdToIndex.get(contentId);
+
+			if (idx === undefined) {
+				idx = chapters.length;
+				contentIdToIndex.set(contentId, idx);
+				chapters.push([title, []]);
+			}
+
+			chapters[idx][1].push(h.bookmark);
+		}
+
+		return chapters;
+	}
 }

--- a/src/modal/ExtractHighlightsModal.ts
+++ b/src/modal/ExtractHighlightsModal.ts
@@ -3,7 +3,7 @@ import { sanitize } from "sanitize-filename-ts";
 import SqlJs from "sql.js";
 import { binary } from "src/binaries/sql-wasm";
 import { HighlightService } from "src/database/Highlight";
-import { Bookmark } from "src/database/interfaces";
+import { Highlight } from "src/database/interfaces";
 import { Repository } from "src/database/repository";
 import { KoboHighlightsImporterSettings } from "src/settings/Settings";
 import { applyTemplateTransformations } from "src/template/template";
@@ -40,52 +40,53 @@ export class ExtractHighlightsModal extends Modal {
 			new Repository(db),
 		);
 
-		const content = service.convertToMap(
-			await service.getAllHighlight(this.settings.sortByChapterProgress),
+		const allHighlights = await service.getAllHighlight(
+			this.settings.sortByChapterProgress,
 		);
 
-		const allBooksContent = new Map<string, Map<string, Bookmark[]>>();
-
-		// Add all books with highlights
-		for (const [bookTitle, chapters] of content) {
-			allBooksContent.set(bookTitle, chapters);
+		// Group highlights by book title.
+		const highlightsByBook = new Map<string, Highlight[]>();
+		for (const h of allHighlights) {
+			const bookTitle = h.content.bookTitle ?? service.unknownBookTitle;
+			if (!highlightsByBook.has(bookTitle))
+				highlightsByBook.set(bookTitle, []);
+			highlightsByBook.get(bookTitle)!.push(h);
 		}
 
+		// Include books with no highlights when the setting is enabled.
 		if (this.settings.importAllBooks) {
-			// Add books without highlights
 			const allBooks = await service.getAllBooks();
-
-			for (const [bookTitle, _] of allBooks) {
-				if (!allBooksContent.has(bookTitle)) {
-					allBooksContent.set(
-						bookTitle,
-						service.createEmptyContentMap(),
-					);
-				}
+			for (const [bookTitle] of allBooks) {
+				if (!highlightsByBook.has(bookTitle))
+					highlightsByBook.set(bookTitle, []);
 			}
 		}
 
-		this.nrOfBooksExtracted = allBooksContent.size;
-		await this.writeBooks(service, allBooksContent);
+		this.nrOfBooksExtracted = highlightsByBook.size;
+		await this.writeBooks(service, highlightsByBook);
 	}
 
 	private async writeBooks(
 		service: HighlightService,
-		content: Map<string, Map<string, Bookmark[]>>,
+		highlightsByBook: Map<string, Highlight[]>,
 	) {
 		const template = await getTemplateContents(
 			this.app,
 			this.settings.templatePath,
 		);
 
-		for (const [bookTitle, chapters] of content) {
+		for (const [bookTitle, bookHighlights] of highlightsByBook) {
 			const sanitizedBookName = sanitize(bookTitle);
 			const fileName = normalizePath(
 				`${this.settings.storageFolder}/${sanitizedBookName}.md`,
 			);
 
-			const details =
-				await service.getBookDetailsFromBookTitle(bookTitle);
+			const [chapters, details] = await Promise.all([
+				Promise.resolve(
+					service.buildChapterList(bookHighlights),
+				),
+				service.getBookDetailsFromBookTitle(bookTitle),
+			]);
 
 			await this.app.vault.adapter.write(
 				fileName,

--- a/src/modal/ExtractHighlightsModal.ts
+++ b/src/modal/ExtractHighlightsModal.ts
@@ -82,9 +82,7 @@ export class ExtractHighlightsModal extends Modal {
 			);
 
 			const [chapters, details] = await Promise.all([
-				Promise.resolve(
-					service.buildChapterList(bookHighlights),
-				),
+				Promise.resolve(service.buildChapterList(bookHighlights)),
 				service.getBookDetailsFromBookTitle(bookTitle),
 			]);
 

--- a/src/template/template.test.ts
+++ b/src/template/template.test.ts
@@ -1,11 +1,11 @@
 import * as chai from "chai";
 import { applyTemplateTransformations, defaultTemplate } from "./template";
-import { chapter } from "../database/Highlight";
-import { Bookmark } from "../database/interfaces";
+import { HighlightService, chapter } from "../database/Highlight";
+import { Bookmark, Highlight } from "../database/interfaces";
 
 describe("template", async function () {
 	const testDate = new Date("2023-01-01T12:00:00Z");
-	const chapters = new Map<chapter, Bookmark[]>([
+	const chapters: [chapter, Bookmark[]][] = [
 		[
 			"Chapter 1",
 			[
@@ -30,7 +30,7 @@ describe("template", async function () {
 				},
 			],
 		],
-	]);
+	];
 
 	function normalize(s: string) {
 		return s
@@ -209,4 +209,36 @@ test2
 			chai.expect(normalize(content)).equal(normalize(t[1]));
 		});
 	}
+
+	it("buildChapterList keeps duplicate chapter titles separate", async function () {
+		const highlights: Highlight[] = [
+			{
+				bookmark: { bookmarkId: "1", text: "highlight in part one", contentId: "c1", dateCreated: testDate },
+				content: { title: "Chapter 1", contentId: "c1", bookTitle: "1984", chapterIdBookmarked: "true" },
+			},
+			{
+				bookmark: { bookmarkId: "2", text: "highlight in part two", contentId: "c2", dateCreated: testDate },
+				content: { title: "Chapter 1", contentId: "c2", bookTitle: "1984", chapterIdBookmarked: "true" },
+			},
+		];
+
+		const service = new HighlightService(null as any);
+		const dedupChapters = service.buildChapterList(highlights);
+
+		chai.expect(dedupChapters).to.have.length(2);
+		chai.expect(dedupChapters[0][0]).to.equal("Chapter 1");
+		chai.expect(dedupChapters[1][0]).to.equal("Chapter 1");
+
+		const content = applyTemplateTransformations(
+			defaultTemplate,
+			dedupChapters,
+			{ title: "1984", author: "George Orwell" },
+		);
+
+		const normalized = normalize(content);
+		const headings = normalized.match(/^## Chapter 1$/gm);
+		chai.expect(headings).to.have.length(2);
+		chai.expect(normalized).to.include("highlight in part one");
+		chai.expect(normalized).to.include("highlight in part two");
+	});
 });

--- a/src/template/template.test.ts
+++ b/src/template/template.test.ts
@@ -213,12 +213,32 @@ test2
 	it("buildChapterList keeps duplicate chapter titles separate", async function () {
 		const highlights: Highlight[] = [
 			{
-				bookmark: { bookmarkId: "1", text: "highlight in part one", contentId: "c1", dateCreated: testDate },
-				content: { title: "Chapter 1", contentId: "c1", bookTitle: "1984", chapterIdBookmarked: "true" },
+				bookmark: {
+					bookmarkId: "1",
+					text: "highlight in part one",
+					contentId: "c1",
+					dateCreated: testDate,
+				},
+				content: {
+					title: "Chapter 1",
+					contentId: "c1",
+					bookTitle: "1984",
+					chapterIdBookmarked: "true",
+				},
 			},
 			{
-				bookmark: { bookmarkId: "2", text: "highlight in part two", contentId: "c2", dateCreated: testDate },
-				content: { title: "Chapter 1", contentId: "c2", bookTitle: "1984", chapterIdBookmarked: "true" },
+				bookmark: {
+					bookmarkId: "2",
+					text: "highlight in part two",
+					contentId: "c2",
+					dateCreated: testDate,
+				},
+				content: {
+					title: "Chapter 1",
+					contentId: "c2",
+					bookTitle: "1984",
+					chapterIdBookmarked: "true",
+				},
 			},
 		];
 

--- a/src/template/template.ts
+++ b/src/template/template.ts
@@ -46,13 +46,12 @@ timeSpentReading: <%= it.bookDetails.timeSpentReading ?? '' %>
 
 export function applyTemplateTransformations(
 	rawTemplate: string,
-	chapters: Map<chapter, Bookmark[]>,
+	chapters: [chapter, Bookmark[]][],
 	bookDetails: BookDetails,
 ): string {
-	const chaptersArr = Array.from(chapters.entries());
 	const rendered = eta.renderString(rawTemplate, {
 		bookDetails,
-		chapters: chaptersArr,
+		chapters,
 		ReadStatus,
 	});
 


### PR DESCRIPTION
Fixes silent merging of highlights between chapters with duplicate names. Part of a set of changes I made to the plugin with Claude Code to improve my Obsidian workflow.

---

## Summary

Books that reuse the same chapter title across multiple parts (e.g. a book structured as "Part One / Chapter 1, Part Two / Chapter 1") previously had all highlights silently merged under a single `## Chapter 1` heading.

This fix groups highlights by `contentId` rather than by chapter title. The new `buildChapterList` method returns an array of `[title, bookmarks]` tuples instead of a Map, so duplicate chapter titles coexist naturally — each distinct content section gets its own heading using the original chapter name, with no renaming or suffixing.

## Changes

- src/database/Highlight.ts — add `buildChapterList()`: groups highlights by `contentId`, returns `[chapter, Bookmark[]][]` with original titles preserved
- src/template/template.ts — `applyTemplateTransformations` now accepts `[chapter, Bookmark[]][]` directly (it was already converting the Map to this shape internally)
- src/modal/ExtractHighlightsModal.ts — rewrite `fetchHighlights` / `writeBooks` to group highlights per book and call `buildChapterList` instead of the previous `convertToMap` path
- src/template/template.test.ts — update test data to use arrays; add test that calls `buildChapterList` with duplicate-titled `Highlight` objects and verifies both `## Chapter 1` headings appear in the rendered output

## Behaviour change

Books with unique chapter titles are unaffected. Books with repeated chapter titles now get separate headings with the same name (e.g. two `## Chapter 1` headings) rather than having highlights silently merged. Chapter order is maintained by the sort in `getAllHighlight`.

## Dead Code

`convertToMap` and `createEmptyContentMap` in `Highlight.ts` are no longer called in the application flow — the modal now groups by book title directly and uses `buildChapterList` per book. Both methods still exist and their tests pass.

---

> **Note:** The implementation in this PR was developed with AI assistance
> (Claude). The logic has been manually reviewed and tested against a real
> Kobo device, but please flag anything that looks wrong.