### PR TITLE
feat: append Kobo highlights to the current note

### DIFF
--- a/src/database/Highlight.ts
+++ b/src/database/Highlight.ts
@@ -13,6 +13,10 @@ export class HighlightService {
 		this.repo = repo;
 	}
 
+	async getBookDetailsByIsbn(isbn: string): Promise<BookDetails | null> {
+		return this.repo.getBookDetailsByIsbn(isbn);
+	}
+
 	async getBookDetailsFromBookTitle(title: string): Promise<BookDetails> {
 		const details = await this.repo.getBookDetailsByBookTitle(title);
 
@@ -176,5 +180,159 @@ export class HighlightService {
 	// Create an empty content map for books without highlights
 	createEmptyContentMap(): Map<chapter, Bookmark[]> {
 		return new Map<chapter, Bookmark[]>();
+	}
+
+	// Efficiently fetches highlights for a single book.
+	//
+	// The naive approach (getAllHighlight + filter) fetches every bookmark in the
+	// database and issues 1-4 DB queries per bookmark to resolve its content,
+	// then discards all results except the target book. For a device with many
+	// books this is extremely wasteful.
+	//
+	// Instead we:
+	//   1. Fetch only this book's bookmarks via a filtered SQL query (1 DB call).
+	//   2. Fetch all content entries for the book ordered by ContentID (1 DB call).
+	//   3. Resolve content associations entirely in-memory — O(M) per bookmark
+	//      where M is the number of chapters, rather than issuing further DB calls.
+	async getHighlightsByBookTitle(
+		bookTitle: string,
+		sortByChapterProgress?: boolean,
+	): Promise<Highlight[]> {
+		const [bookmarks, allContents] = await Promise.all([
+			this.repo.getBookmarksByBookTitle(bookTitle, sortByChapterProgress),
+			this.repo.getAllContentByBookTitleOrderedByContentId(bookTitle),
+		]);
+
+		// Build an exact-match index for O(1) lookups.
+		const contentById = new Map<string, Content>(
+			allContents.map((c) => [c.contentId, c]),
+		);
+
+		const highlights: Highlight[] = [];
+		for (const bookmark of bookmarks) {
+			highlights.push(
+				this.resolveHighlightInMemory(
+					bookmark,
+					bookTitle,
+					contentById,
+					allContents,
+				),
+			);
+		}
+
+		return highlights;
+	}
+
+	// In-memory equivalent of createHighlightFromBookmark + findRightContentForBookmark,
+	// using pre-fetched content data to avoid per-bookmark DB queries.
+	private resolveHighlightInMemory(
+		bookmark: Bookmark,
+		bookTitle: string,
+		contentById: Map<string, Content>,
+		allContents: Content[], // ordered by ContentID
+	): Highlight {
+		// 1. Exact match.
+		let content = contentById.get(bookmark.contentId) ?? null;
+
+		// 2. Fuzzy match: find a content entry whose ContentID contains the bookmark's ContentID.
+		if (!content) {
+			content =
+				allContents.find((c) =>
+					c.contentId.includes(bookmark.contentId),
+				) ?? null;
+		}
+
+		if (!content) {
+			console.warn(
+				`bookmark seems to link to a non existing content: ${bookmark.contentId}`,
+			);
+			return {
+				bookmark,
+				content: {
+					title: this.unknownBookTitle,
+					contentId: bookmark.contentId,
+					chapterIdBookmarked: "false",
+					bookTitle: this.unknownBookTitle,
+				},
+			};
+		}
+
+		// 3. If chapterIdBookmarked is null, walk the sorted content list to find
+		//    the right chapter — mirrors findRightContentForBookmark logic.
+		if (content.chapterIdBookmarked == null) {
+			content = this.findRightContentInMemory(
+				bookmark,
+				content,
+				allContents,
+			);
+		}
+
+		return { bookmark, content };
+	}
+
+	// In-memory equivalent of findRightContentForBookmark.
+	private findRightContentInMemory(
+		bookmark: Bookmark,
+		originalContent: Content,
+		allContents: Content[], // ordered by ContentID
+	): Content {
+		// Mirror getFirstContentLikeContentIdWithBookmarkIdNotNull:
+		// find a content whose ContentID starts with originalContent's ContentID
+		// and has chapterIdBookmarked set.
+		const potential = allContents.find(
+			(c) =>
+				c.contentId.startsWith(originalContent.contentId) &&
+				c.chapterIdBookmarked != null,
+		);
+		if (potential) return potential;
+
+		// Fall back to sequential scan (mirrors the for-loop in findRightContentForBookmark).
+		let foundContent: Content | null = null;
+		for (const c of allContents) {
+			if (c.chapterIdBookmarked) {
+				foundContent = c;
+			}
+			if (c.contentId === bookmark.contentId && foundContent) {
+				return foundContent;
+			}
+		}
+
+		if (foundContent) {
+			console.warn(
+				`was not able to find chapterIdBookmarked for book ${originalContent.bookTitle}`,
+			);
+		}
+
+		return originalContent;
+	}
+
+	// Groups highlights for a single book into a chapter map.
+	//
+	// When the same chapter title appears under different content entries
+	// (e.g. "Chapter 1" in Part One and "Chapter 1" in Part Two of 1984),
+	// each distinct contentId gets its own map key. The second occurrence is
+	// named "Chapter 1 (2)", the third "Chapter 1 (3)", so highlights are
+	// never silently merged.
+	buildChapterMapWithDedup(highlights: Highlight[]): Map<chapter, Bookmark[]> {
+		const chapterMap = new Map<chapter, Bookmark[]>();
+		const contentIdToKey = new Map<string, string>();
+		const titleCount = new Map<string, number>();
+
+		for (const h of highlights) {
+			const { title, contentId } = h.content;
+			let key = contentIdToKey.get(contentId);
+
+			if (key === undefined) {
+				const count = (titleCount.get(title) ?? 0) + 1;
+				titleCount.set(title, count);
+				key = count === 1 ? title : `${title} (${count})`;
+				contentIdToKey.set(contentId, key);
+				chapterMap.set(key, []);
+			}
+
+			chapterMap.get(key)!.push(h.bookmark);
+		}
+
+		return chapterMap;
 	}
 }

--- a/src/database/repository.ts
+++ b/src/database/repository.ts
@@ -220,6 +220,87 @@ export class Repository {
 		};
 	}
 
+	async getBookmarksByBookTitle(
+		bookTitle: string,
+		sortByChapterProgress?: boolean,
+	): Promise<Bookmark[]> {
+		const orderBy = sortByChapterProgress
+			? "b.ChapterProgress ASC, b.DateCreated ASC"
+			: "b.DateCreated ASC";
+
+		// Use EXISTS with a parameterized bind to filter bookmarks to this book,
+		// handling both exact ContentID matches and fuzzy matches (where
+		// content.ContentID contains the bookmark's ContentID as a substring).
+		// The ORDER BY clause uses an internally-derived string (not user input)
+		// so interpolating it is safe.
+		const statement = this.db.prepare(
+			`SELECT b.BookmarkID, b.Text, b.ContentID, b.annotation, b.DateCreated
+			FROM Bookmark b
+			WHERE b.Text IS NOT NULL
+			AND EXISTS (
+				SELECT 1 FROM content c
+				WHERE c.BookTitle = $bookTitle
+				AND (c.ContentID = b.ContentID OR c.ContentID LIKE '%' || b.ContentID || '%')
+			)
+			ORDER BY ${orderBy};`,
+			{ $bookTitle: bookTitle },
+		);
+
+		const bookmarks: Bookmark[] = [];
+
+		while (statement.step()) {
+			const row = statement.get();
+			if (!(row[0] && row[1] && row[2] && row[4])) {
+				console.warn("Skipping bookmark with invalid values", row);
+				continue;
+			}
+
+			bookmarks.push({
+				bookmarkId: row[0].toString(),
+				text: row[1].toString().replace(/\s+/g, " ").trim(),
+				contentId: row[2].toString(),
+				note: row[3]?.toString(),
+				dateCreated: new Date(row[4].toString()),
+			});
+		}
+
+		statement.free();
+		return bookmarks;
+	}
+
+	async getBookDetailsByIsbn(isbn: string): Promise<BookDetails | null> {
+		const statement = this.db.prepare(
+			`SELECT DISTINCT Title, Attribution as Author, Description, Publisher, DateLastRead, ReadStatus, ___PercentRead, ISBN, Series, SeriesNumber, TimeSpentReading FROM content WHERE ISBN = $isbn AND Title IS NOT NULL LIMIT 1;`,
+			{ $isbn: isbn },
+		);
+
+		if (!statement.step()) {
+			statement.free();
+			return null;
+		}
+
+		const row = statement.get();
+		statement.free();
+
+		if (row[0] == null) {
+			return null;
+		}
+
+		return {
+			title: row[0].toString(),
+			author: row[1]?.toString() ?? "Unknown Author",
+			description: row[2]?.toString(),
+			publisher: row[3]?.toString(),
+			dateLastRead: row[4] ? new Date(row[4].toString()) : undefined,
+			readStatus: row[5] ? +row[5].toString() : 0,
+			percentRead: row[6] ? +row[6].toString() : 0,
+			isbn: row[7]?.toString(),
+			series: row[8]?.toString(),
+			seriesNumber: row[9] ? +row[9].toString() : undefined,
+			timeSpentReading: row[10] ? +row[10].toString() : 0,
+		};
+	}
+
 	async getAllBookDetails(): Promise<BookDetails[]> {
 		const statement = this.db.prepare(
 			`SELECT DISTINCT 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
-import { addIcon, Plugin } from "obsidian";
+import { addIcon, Notice, Plugin } from "obsidian";
+import { AppendHighlightsModal } from "./modal/AppendHighlightsModal";
 import { ExtractHighlightsModal } from "./modal/ExtractHighlightsModal";
 import {
 	DEFAULT_SETTINGS,
@@ -35,6 +36,42 @@ export default class KoboHighlightsImporter extends Plugin {
 				new ExtractHighlightsModal(this.app, this.settings).open();
 			},
 		});
+
+		this.addCommand({
+			id: "append-kobo-highlights-to-note",
+			name: "Append Kobo highlights to current note",
+			editorCallback: (editor, ctx) => {
+				if (!ctx.file) {
+					new Notice("No active file open");
+					return;
+				}
+				new AppendHighlightsModal(
+					this.app,
+					this.settings,
+					ctx.file,
+					() => this.saveSettings(),
+				).open();
+			},
+		});
+
+		const appendIconEl = this.addRibbonIcon(
+			"book-plus",
+			"Append Kobo highlights to current note",
+			() => {
+				const activeFile = this.app.workspace.getActiveFile();
+				if (!activeFile) {
+					new Notice("No active file open");
+					return;
+				}
+				new AppendHighlightsModal(
+					this.app,
+					this.settings,
+					activeFile,
+					() => this.saveSettings(),
+				).open();
+			},
+		);
+		appendIconEl.addClass("kobo-highlights-append-icon");
 
 		// This adds a settings tab so the user can configure various aspects of the plugin
 		this.addSettingTab(

--- a/src/modal/AppendHighlightsModal.ts
+++ b/src/modal/AppendHighlightsModal.ts
@@ -1,0 +1,241 @@
+import { webUtils } from "electron";
+import { readFileSync } from "fs";
+import { App, Modal, Notice, TFile } from "obsidian";
+import SqlJs from "sql.js";
+import { binary } from "src/binaries/sql-wasm";
+import { HighlightService } from "src/database/Highlight";
+import { BookDetails } from "src/database/interfaces";
+import { Repository } from "src/database/repository";
+import { KoboHighlightsImporterSettings } from "src/settings/Settings";
+import {
+	applyTemplateTransformations,
+	defaultAppendTemplate,
+} from "src/template/template";
+import { getTemplateContents } from "src/template/templateContents";
+import { BookPickerModal } from "./BookPickerModal";
+
+export class AppendHighlightsModal extends Modal {
+	goButtonEl!: HTMLButtonElement;
+	inputFileEl!: HTMLInputElement;
+
+	settings: KoboHighlightsImporterSettings;
+	saveSettings: () => Promise<void>;
+	activeFile: TFile;
+
+	fileBuffer: ArrayBuffer | null | undefined;
+
+	constructor(
+		app: App,
+		settings: KoboHighlightsImporterSettings,
+		activeFile: TFile,
+		saveSettings: () => Promise<void>,
+	) {
+		super(app);
+		this.settings = settings;
+		this.saveSettings = saveSettings;
+		this.activeFile = activeFile;
+	}
+
+	private getFrontmatterValue(key: string): string | undefined {
+		const cache = this.app.metadataCache.getFileCache(this.activeFile);
+		const value = cache?.frontmatter?.[key];
+		if (value && typeof value === "string" && value.trim()) {
+			return value.trim();
+		}
+		return undefined;
+	}
+
+	private async appendHighlightsForBook(
+		service: HighlightService,
+		bookTitle: string,
+	) {
+		const highlights = await service.getHighlightsByBookTitle(
+			bookTitle,
+			this.settings.sortByChapterProgress,
+		);
+
+		if (highlights.length === 0) {
+			new Notice(
+				`No highlights found for "${bookTitle}" in the Kobo database`,
+			);
+			return;
+		}
+
+		const [chapters, details] = await Promise.all([
+			Promise.resolve(service.buildChapterMapWithDedup(highlights)),
+			service.getBookDetailsFromBookTitle(bookTitle),
+		]);
+
+		const template = await getTemplateContents(
+			this.app,
+			this.settings.appendTemplatePath,
+			defaultAppendTemplate,
+		);
+
+		const rendered = applyTemplateTransformations(
+			template,
+			chapters,
+			details,
+		);
+
+		const currentContent = await this.app.vault.read(this.activeFile);
+		await this.app.vault.modify(
+			this.activeFile,
+			currentContent + "\n\n" + rendered,
+		);
+
+		new Notice(
+			`Appended ${highlights.length} highlights from "${bookTitle}"`,
+		);
+	}
+
+	private async fetchAndAppendHighlights() {
+		if (!this.fileBuffer) {
+			throw new Error("No sqlite DB file selected...");
+		}
+
+		const SQLEngine = await SqlJs({
+			wasmBinary: binary.buffer,
+		});
+
+		const db = new SQLEngine.Database(new Uint8Array(this.fileBuffer));
+		const service = new HighlightService(new Repository(db));
+
+		// Try ISBN match first.
+		const isbn = this.getFrontmatterValue("isbn");
+		if (isbn) {
+			const bookByIsbn = await service.getBookDetailsByIsbn(isbn);
+			if (bookByIsbn) {
+				await this.appendHighlightsForBook(service, bookByIsbn.title);
+				return;
+			}
+		}
+
+		// Fall back to book picker.
+		const noteTitle =
+			this.getFrontmatterValue("title") ?? this.activeFile.basename;
+		const allBooks = await service.getAllBooks();
+		const bookList = Array.from(allBooks.values());
+
+		this.close();
+
+		new BookPickerModal(
+			this.app,
+			bookList,
+			noteTitle,
+			async (selected: BookDetails) => {
+				try {
+					await this.appendHighlightsForBook(
+						service,
+						selected.title,
+					);
+				} catch (e) {
+					console.error(e);
+					new Notice(
+						"Something went wrong... Check console for more details.",
+					);
+				}
+			},
+		).open();
+	}
+
+	private enableButton() {
+		this.goButtonEl.disabled = false;
+		this.goButtonEl.setAttr(
+			"style",
+			"background-color: green; color: black",
+		);
+	}
+
+	private tryLoadStoredPath() {
+		if (!this.settings.sqlitePath) return;
+
+		try {
+			const buf = readFileSync(this.settings.sqlitePath);
+			this.fileBuffer = buf.buffer.slice(
+				buf.byteOffset,
+				buf.byteOffset + buf.byteLength,
+			);
+			this.enableButton();
+			new Notice(`Loaded KoboReader.sqlite from remembered path`);
+		} catch {
+			new Notice(
+				`Could not load sqlite file from remembered path — please select it manually`,
+			);
+		}
+	}
+
+	onOpen() {
+		const { contentEl } = this;
+
+		this.goButtonEl = contentEl.createEl("button");
+		this.goButtonEl.textContent = "Append";
+		this.goButtonEl.disabled = true;
+		this.goButtonEl.setAttr("style", "background-color: red; color: white");
+		this.goButtonEl.addEventListener("click", () => {
+			new Notice("Extracting highlights...");
+			this.fetchAndAppendHighlights()
+				.then(() => {
+					this.close();
+				})
+				.catch((e) => {
+					console.error(e);
+					new Notice(
+						"Something went wrong... Check console for more details.",
+					);
+				});
+		});
+
+		this.inputFileEl = contentEl.createEl("input");
+		this.inputFileEl.type = "file";
+		this.inputFileEl.accept = ".sqlite";
+		this.inputFileEl.addEventListener("change", (ev) => {
+			const file = (ev.target as HTMLInputElement)?.files?.[0];
+			if (!file) {
+				console.error("No file selected");
+				return;
+			}
+
+			// Save the path for future sessions using Electron's webUtils API.
+			const filePath = webUtils.getPathForFile(file);
+			if (filePath) {
+				this.settings.sqlitePath = filePath;
+				this.saveSettings();
+			}
+
+			const reader = new FileReader();
+			reader.onload = () => {
+				this.fileBuffer = reader.result as ArrayBuffer;
+				this.enableButton();
+				new Notice("Ready to extract!");
+			};
+
+			reader.onerror = (error) => {
+				console.error("FileReader error:", error);
+				new Notice("Error reading file");
+			};
+
+			reader.readAsArrayBuffer(file);
+		});
+
+		const heading = contentEl.createEl("h2");
+		heading.textContent = "Append Kobo Highlights";
+
+		const description = contentEl.createEl("p");
+		description.innerHTML =
+			"Please select your <em>KoboReader.sqlite</em> file from a connected device";
+
+		contentEl.appendChild(heading);
+		contentEl.appendChild(description);
+		contentEl.appendChild(this.inputFileEl);
+		contentEl.appendChild(this.goButtonEl);
+
+		// Try to auto-load from the remembered path after the UI is shown.
+		this.tryLoadStoredPath();
+	}
+
+	onClose() {
+		const { contentEl } = this;
+		contentEl.empty();
+	}
+}

--- a/src/modal/BookPickerModal.ts
+++ b/src/modal/BookPickerModal.ts
@@ -1,0 +1,40 @@
+import { FuzzySuggestModal, App } from "obsidian";
+import { BookDetails } from "src/database/interfaces";
+
+export class BookPickerModal extends FuzzySuggestModal<BookDetails> {
+	private books: BookDetails[];
+	private onChoose: (_book: BookDetails) => void;
+	private initialQuery: string;
+
+	constructor(
+		app: App,
+		books: BookDetails[],
+		initialQuery: string,
+		onChoose: (_book: BookDetails) => void,
+	) {
+		super(app);
+		this.books = books;
+		this.onChoose = onChoose;
+		this.initialQuery = initialQuery;
+		this.setPlaceholder("Search for your book...");
+	}
+
+	onOpen() {
+		super.onOpen();
+		this.inputEl.value = this.initialQuery;
+		// Trigger the input event so the fuzzy search filters on the initial query
+		this.inputEl.dispatchEvent(new Event("input"));
+	}
+
+	getItems(): BookDetails[] {
+		return this.books;
+	}
+
+	getItemText(_book: BookDetails): string {
+		return `${book.title} — ${book.author}`;
+	}
+
+	onChooseItem(_book: BookDetails): void {
+		this.onChoose(book);
+	}
+}

--- a/src/modal/BookPickerModal.ts
+++ b/src/modal/BookPickerModal.ts
@@ -30,11 +30,11 @@ export class BookPickerModal extends FuzzySuggestModal<BookDetails> {
 		return this.books;
 	}
 
-	getItemText(_book: BookDetails): string {
+	getItemText(book: BookDetails): string {
 		return `${book.title} — ${book.author}`;
 	}
 
-	onChooseItem(_book: BookDetails): void {
+	onChooseItem(book: BookDetails): void {
 		this.onChoose(book);
 	}
 }

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -7,14 +7,18 @@ export const DEFAULT_SETTINGS: KoboHighlightsImporterSettings = {
 	storageFolder: "",
 	sortByChapterProgress: false,
 	templatePath: "",
+	appendTemplatePath: "",
 	importAllBooks: false,
+	sqlitePath: "",
 };
 
 export interface KoboHighlightsImporterSettings {
 	storageFolder: string;
 	sortByChapterProgress: boolean;
 	templatePath: string;
+	appendTemplatePath: string;
 	importAllBooks: boolean;
+	sqlitePath: string;
 }
 
 export class KoboHighlightsImporterSettingsTab extends PluginSettingTab {
@@ -31,6 +35,7 @@ export class KoboHighlightsImporterSettingsTab extends PluginSettingTab {
 
 		this.add_destination_folder();
 		this.add_template_path();
+		this.add_append_template_path();
 		this.add_sort_by_chapter_progress();
 		this.add_import_all_books();
 	}
@@ -60,6 +65,24 @@ export class KoboHighlightsImporterSettingsTab extends PluginSettingTab {
 					.setValue(this.plugin.settings.templatePath)
 					.onChange((newTemplatePath) => {
 						this.plugin.settings.templatePath = newTemplatePath;
+						this.plugin.saveSettings();
+					});
+			});
+	}
+
+	add_append_template_path(): void {
+		new Setting(this.containerEl)
+			.setName("Append Template Path")
+			.setDesc(
+				"Template used when appending highlights to an existing note",
+			)
+			.addSearch((cb) => {
+				new FileSuggestor(this.app, cb.inputEl);
+				cb.setPlaceholder("Example: folder1/append-template")
+					.setValue(this.plugin.settings.appendTemplatePath)
+					.onChange((newTemplatePath) => {
+						this.plugin.settings.appendTemplatePath =
+							newTemplatePath;
 						this.plugin.saveSettings();
 					});
 			});

--- a/src/template/template.ts
+++ b/src/template/template.ts
@@ -44,6 +44,27 @@ timeSpentReading: <%= it.bookDetails.timeSpentReading ?? '' %>
 <% }) %>
 `;
 
+export const defaultAppendTemplate = `
+## Highlights
+
+<% it.chapters.forEach(([chapterName, highlights]) => { -%>
+## <%= chapterName.trim() %>
+
+<% highlights.forEach((highlight) => { -%>
+<%= highlight.text %>
+
+<% if (highlight.note) { -%>
+**Note:** <%= highlight.note %>
+
+<% } -%>
+<% if (highlight.dateCreated) { -%>
+*Created: <%= highlight.dateCreated.toISOString() %>*
+
+<% } -%>
+<% }) -%>
+<% }) %>
+`;
+
 export function applyTemplateTransformations(
 	rawTemplate: string,
 	chapters: Map<chapter, Bookmark[]>,

--- a/src/template/templateContents.ts
+++ b/src/template/templateContents.ts
@@ -6,11 +6,12 @@ import { defaultTemplate } from "./template";
 export async function getTemplateContents(
 	app: App,
 	templatePath: string | undefined,
+	fallback: string = defaultTemplate,
 ): Promise<string> {
 	const { metadataCache, vault } = app;
 	const normalizedTemplatePath = normalizePath(templatePath ?? "");
 	if (normalizedTemplatePath === "/") {
-		return defaultTemplate;
+		return fallback;
 	}
 
 	try {
@@ -18,7 +19,7 @@ export async function getTemplateContents(
 			normalizedTemplatePath,
 			"",
 		);
-		return templateFile ? vault.cachedRead(templateFile) : defaultTemplate;
+		return templateFile ? vault.cachedRead(templateFile) : fallback;
 	} catch (err) {
 		console.error(
 			`Failed to read the kobo highlight exporter template '${normalizedTemplatePath}'`,

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -1,0 +1,5 @@
+declare module "electron" {
+	export const webUtils: {
+		getPathForFile(_file: File): string;
+	};
+}


### PR DESCRIPTION
Adds ability to append highlights to the current note by command & ribbon button, and adds a new append template setting. Similar to PR #107, which it seems never actually made it to release. Part of a set of changes I made to the plugin with Claude Code to improve my Obsidian workflow.

> Opening as draft to establish context. Will mark ready after #519, #520, #521 are reviewed, as this PR implements some of those changes specifically to the append function.

---

## Summary

Adds an "Append Kobo highlights" command and ribbon icon. When run from
inside a book note, it fetches only that book's highlights from the Kobo
database and appends them to the active file — without overwriting the
existing note content.

**Book matching:** The command reads the `isbn` field from the active note's
YAML frontmatter and matches it against the Kobo database. If no ISBN is
found (or no match), a fuzzy book picker appears, pre-filtered by the note's
filename.

**Path memory:** After the first successful file pick, the path to
`KoboReader.sqlite` is persisted in settings and auto-loaded on subsequent
runs (same mechanism as the "Remember sqlite path" PR, independent but
compatible).

**Template:** A separate append template can be configured in Settings
(`Append Template Path`). It defaults to a highlights-only template
(no frontmatter or title header) appropriate for appending to an existing
note. The full Eta template engine is available, with the same `it.chapters`
and `it.bookDetails` variables as the main template.

**Chapter dedup:** Highlights from same-named chapters in different parts of
a book are kept under distinct headings (`Chapter 1`, `Chapter 1 (2)`, …)
rather than merged — same fix as the "Chapter name dedup" PR, included here
so the append flow works correctly standalone.

## Changes

- `src/database/repository.ts` — add `getBookmarksByBookTitle()` (filtered
  bookmark fetch for a single book) and `getBookDetailsByIsbn()`
- `src/database/Highlight.ts` — add `getHighlightsByBookTitle()` (efficient
  single-book fetch with in-memory content resolution, avoiding the O(N·M)
  cost of the global fetch-and-filter approach); `buildChapterMapWithDedup()`;
  private `resolveHighlightInMemory` / `findRightContentInMemory` helpers
- `src/modal/AppendHighlightsModal.ts` — **new file**: file picker with path
  persistence → ISBN frontmatter match → `BookPickerModal` fallback → renders
  append template and appends to active file
- `src/modal/BookPickerModal.ts` — **new file**: `FuzzySuggestModal<BookDetails>`
  pre-seeded with the note title
- `src/template/template.ts` — export `defaultAppendTemplate`
- `src/template/templateContents.ts` — add optional `fallback` parameter to
  `getTemplateContents()`
- `src/settings/Settings.ts` — add `appendTemplatePath` and `sqlitePath`
  fields + settings-tab entries
- `src/main.ts` — register `append-kobo-highlights-to-note` command with
  `editorCallback` and a ribbon icon
- `src/types/electron.d.ts` — **new file** declaring `webUtils` types

## Notes

- A similar feature was introduced in PR #107 (Jan 2024) but was removed as
  collateral during the Eta templating refactor in PR #405 (Sep 2025). This
  reimplements it against the current codebase.
- The dedup fix and path memory are self-contained within this PR so it
  works standalone. The same fixes also ship separately in the "Chapter name
  dedup" and "Remember sqlite path" PRs for the main extract flow. If all
  three are merged, a minor conflict on the `sqlitePath` and
  `buildChapterMapWithDedup` additions is expected and easy to resolve.
- Output quality benefits from the "Sort chapters by VolumeIndex" PR but
  does not require it.

## Related

- Closes #243 — append highlights to existing note  
- Related to #91

---

> **Note:** The implementation in this PR was developed with AI assistance
> (Claude). The logic has been manually reviewed and tested against a real
> Kobo device, but please flag anything that looks wrong.